### PR TITLE
refactor: worker interface + ErrorHTML feat

### DIFF
--- a/lib/platform/edgehooks/ErrorHTML/ErrorHTML.hooks.js
+++ b/lib/platform/edgehooks/ErrorHTML/ErrorHTML.hooks.js
@@ -1,0 +1,96 @@
+/**
+ * Formats the request and error information for logging.
+ * @param {Error} error - The error object.
+ * @returns {string} The formatted log string.
+ */
+function formatLog(error) {
+  let formattedLog = '';
+
+  if (error) {
+    const formattedError = error instanceof Error ? error.stack : error;
+    formattedLog += `<b>Error:</b>\n${formattedError}`;
+  }
+
+  return formattedLog;
+}
+
+/**
+ * Creates the HTML content for the custom error page.
+ * @param {number} errorCode - The error code.
+ * @param {string} errorDescription - The error description.
+ * @param {Error} [error] - The debug object containing error object.
+ * @returns {string} The HTML content.
+ */
+function createErrorHTML(errorCode, errorDescription, error) {
+  const formattedLog = formatLog(error);
+
+  return `<!DOCTYPE html>
+      <html lang="en">
+      <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>Error ${errorCode} - ${errorDescription}</title>
+        <style>
+          body {
+            background-color: black;
+            color: rgb(255, 108, 55);
+            font-family: Arial, sans-serif;
+            text-align: center;
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            align-items: center;
+            height: 100vh;
+            margin: 0;
+          }
+          h1 {
+            font-size: 36px;
+            margin-bottom: 10px;
+            animation: levitate 2s ease-in-out infinite alternate;
+          }
+          p {
+            font-size: 18px;
+            margin-bottom: 5px;
+          }
+          a {
+            color: rgb(255, 108, 55);
+            text-decoration: none;
+          }
+      
+          @keyframes levitate {
+            0% {
+              transform: translateY(0);
+            }
+            50% {
+              transform: translateY(-10px);
+            }
+            100% {
+              transform: translateY(0);
+            }
+          }
+        </style>
+      </head>
+      <body>
+        <h1>Error ${errorCode}</h1>
+        <p>${errorDescription || ''}</p>
+        <pre>${formattedLog}</pre>
+      </body>
+      </html>`;
+}
+
+/**
+ * Handles an error by logging the request and error information
+ * and returning a custom HTML response.
+ * @param {number} code - The error code.
+ * @param {string} description - The error description.
+ * @param {Error} [error] - The error object for debugging (optional).
+ *                          If provided, the error will be displayed on the error page.
+ *  @returns {Response} The custom HTML response.
+ */
+function ErrorHTML(code, description, error) {
+  const errorHTML = createErrorHTML(code, description, error);
+  const headers = { 'Content-Type': 'text/html' };
+  return new Response(errorHTML, { status: code, headers });
+}
+
+export default ErrorHTML;

--- a/lib/platform/edgehooks/ErrorHTML/index.js
+++ b/lib/platform/edgehooks/ErrorHTML/index.js
@@ -1,0 +1,3 @@
+import Error from './Error.js';
+
+export default Error;

--- a/lib/platform/edgehooks/index.js
+++ b/lib/platform/edgehooks/index.js
@@ -1,4 +1,5 @@
 import mountSPA from './mountSPA/mountSPA.hooks.js';
 import mountSSG from './mountSSG/mountSSG.hooks.js';
-// eslint-disable-next-line import/prefer-default-export
-export { mountSPA, mountSSG };
+import ErrorHTML from './ErrorHTML/ErrorHTML.hooks.js';
+
+export { mountSPA, mountSSG, ErrorHTML };

--- a/lib/platform/edgehooks/mountSPA/mountSPA.hooks.js
+++ b/lib/platform/edgehooks/mountSPA/mountSPA.hooks.js
@@ -1,9 +1,10 @@
 /**
- * Mounts a request URL for Single-Page Applications (SPA)
+ * Mounts a request for Single Page App(SPA) based on
+ * the provided request URL and version ID.
  * based on the provided request URL and version ID.
  * @param {string} requestURL - The original URL from the event request.
  * @param {string} versionId - The version ID representing the build/assets stored.
- * @returns {URL} The mounted request URL for the SPA.
+ * @returns {Promise<Response>} A promise that resolves to the response from the SPA.
  */
 export default function mountSPA(requestURL, versionId) {
   /**
@@ -31,5 +32,5 @@ export default function mountSPA(requestURL, versionId) {
     assetPath = new URL(`/${versionId}/index.html`, 'file://');
   }
 
-  return new URL(assetPath, 'file://');
+  return fetch(assetPath);
 }

--- a/lib/platform/edgehooks/mountSSG/mountSSG.hooks.js
+++ b/lib/platform/edgehooks/mountSSG/mountSSG.hooks.js
@@ -1,9 +1,13 @@
 /**
- * Mounts a request URL for Static Site Generation (SSG)
+/**
+ * Mounts a request for Static Site Generation (SSG) based on
+ * the provided request URL and version ID.
+ * The function constructs the appropriate asset path based on the request URL and version ID,
+ * and fetches the corresponding response from the SSG.
  * based on the provided request URL and version ID.
  * @param {string} requestURL - The original URL from the event request.
  * @param {string} versionId - The version ID representing the build/assets stored.
- * @returns {URL} The mounted request URL for SSG.
+ * @returns {Promise<Response>} A promise that resolves to the response from the SSG.
  */
 export default function mountSSG(requestURL, versionId) {
   /**
@@ -38,5 +42,5 @@ export default function mountSSG(requestURL, versionId) {
     assetPath = new URL(`/${versionId}${cleanRequestPath}/index.html`, 'file://');
   }
 
-  return new URL(assetPath, 'file://');
+  return fetch(assetPath);
 }

--- a/lib/presets/frameworks/astro/static/handler.js
+++ b/lib/presets/frameworks/astro/static/handler.js
@@ -1,9 +1,8 @@
-import { mountSSG } from "#edge";
+import { mountSSG, ErrorHTML } from "#edge";
 
 try {
-  const myApp = mountSSG(event.request.url, AZION.VERSION_ID);
-  const response = await fetch(myApp)
-  return response;
-} catch (e) {
-  return new Response(e.message || e.toString(), { status: 500 }); // TODO: create Azion/Vulcan custom 404
+  const myApp = await mountSSG(event.request.url, AZION.VERSION_ID);
+  return myApp;
+} catch (error) {
+  return ErrorHTML("404");
 }

--- a/lib/presets/frameworks/next/static/handler.js
+++ b/lib/presets/frameworks/next/static/handler.js
@@ -1,9 +1,8 @@
 import { mountSSG } from "#edge";
 
   try {
-    const myApp = mountSSG(event.request.url, AZION.VERSION_ID);
-    const response = await fetch(myApp)
-    return response;
+    const myApp = await mountSSG(event.request.url, AZION.VERSION_ID);
+    return myApp;
   } catch (e) {
     const notFoundError = new URL(`${AZION.VERSION_ID}/404.html`, 'file://')
     return fetch(notFoundError)

--- a/lib/presets/frameworks/react/static/handler.js
+++ b/lib/presets/frameworks/react/static/handler.js
@@ -1,9 +1,8 @@
 import { mountSPA } from "#edge";
 
   try {
-    const myApp = mountSPA(event.request.url, AZION.VERSION_ID);
-    const response = await fetch(myApp)
-    return response;
+    const myApp = await mountSPA(event.request.url, AZION.VERSION_ID);
+    return myApp;
   } catch (e) {
     return new Response(e.message || e.toString(), { status: 500 }); // TODO: create Azion/Vulcan custom 404
   }

--- a/lib/presets/frameworks/vue/static/handler.js
+++ b/lib/presets/frameworks/vue/static/handler.js
@@ -1,9 +1,8 @@
 import { mountSPA } from "#edge";
 
   try {
-    const myApp = mountSPA(event.request.url, AZION.VERSION_ID);
-    const response = await fetch(myApp)
-    return response;
+    const myApp = await mountSPA(event.request.url, AZION.VERSION_ID);
+    return myApp;
   } catch (e) {
     return new Response(e.message || e.toString(), { status: 500 }); // TODO: create Azion/Vulcan custom 404
   }


### PR DESCRIPTION
- Improve worker response interface (mount hooks now returns response)
- Create a standard error (#edge) for deploys via Vulcan (user can import and use if they want). The HTML template can and should be updated in the future. [#Issue 35](https://github.com/aziontech/vulcan/issues/35)


## Before:
<img width="544" alt="image" src="https://github.com/aziontech/vulcan/assets/12740219/6cd504e8-1115-402a-8f62-59cadd968510">

## After:
<img width="650" alt="image" src="https://github.com/aziontech/vulcan/assets/12740219/49ad7f6d-bd1c-41a2-b797-0fb0626b8f6d">



ps:
Nomenclatures will still change.
