### PR TITLE
feat: adding clean output mode for logs

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -76,6 +76,7 @@
     }
   },
   "rules": {
+    "no-console": "off",
     "import/extensions": [
       "error",
       "always"

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ coverage
 .DS_Store
 out
 .temp
+.edge
+jsdoc

--- a/lib/utils/feedback/feedback.utils.js
+++ b/lib/utils/feedback/feedback.utils.js
@@ -1,11 +1,30 @@
 import signale from 'signale';
+
+const cleanOutputEnabled = process.env.CLEAN_OUTPUT_MODE === 'true';
+const cleanOutputConfig = {
+  displayScope: false,
+  displayBadge: false,
+  displayDate: false,
+  displayFilename: false,
+  displayLabel: false,
+  displayTimestamp: false,
+  underlineLabel: false,
+  underlineMessage: false,
+  underlinePrefix: false,
+  underlineSuffix: false,
+  uppercaseLabel: false,
+};
+
 /**
- * Helper function to create a custom logger object.
+ * Helper function to create a custom interactive logger object.
  * @param {object} options - Configuration options for the logger.
  * @returns {object} A custom logger object.
  */
 const getLogger = (options = {}) => {
   const logger = new signale.Signale({ ...options });
+  if (cleanOutputEnabled) {
+    logger.config(cleanOutputConfig);
+  }
   return Object.assign(logger, {
     breakInteractiveChain: () => console.log(),
   });
@@ -26,11 +45,11 @@ const methods = {
   },
 };
 
-/**
- * Global log object.
- * @type {object}
- */
 const global = new signale.Signale({ interactive: false, scope: 'Vulcan', types: methods });
+
+if (cleanOutputEnabled) {
+  global.config(cleanOutputConfig);
+}
 
 /**
  * Predefined log scopes.
@@ -45,24 +64,18 @@ const scopes = {
   propagation: { ...global.scope('Azion', 'Edge Network'), interactive: getLogger({ interactive: true, scope: ['Vulcan', 'Azion Network'], types: methods }) },
 };
 /**
+ * @name feedback
+ * @memberof Utils
+ * @description
  * Feedback object that facilitates log display.
+ * It includes all logging methods provided by 'signale'.
+ * If the environment variable CLEAN_OUTPUT_MODE is set to 'true', all log methods use console.log,
+ * providing cleaner and unstyled output. This is particularly useful
+ * for other clients intending to use Vulcan
+ * in the background, where stylized console output may be less desirable.
+ * For more information about the Signale logging methods, refer to its documentation (https://github.com/klaussinani/signale).
  * @type {object}
- * @property {Function} success - Log method for a successful operation.
- * @property {Function} error - Log method for an error during an operation.
- * @property {Function} fatal - Log method for an fatal error during an operation.
- *  @property {Function} info - Log method for providing information about platform operations.
- * @property {Function} await - Log method for awaiting an interactive operation.
- * @property {Function} complete - Log method for a completed interactive operation.
  */
-
-const feedback = {
-  time(label) {
-    signale.time(label);
-  },
-  timeEnd(label) {
-    signale.timeEnd(label);
-  },
-  ...scopes,
-};
+const feedback = { ...scopes };
 
 export default feedback;

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -11,10 +11,8 @@ import readWorkerFile from './readWorkerFile/index.js';
 import overrideStaticOutputPath from './overrideStaticOutputPath/index.js';
 import getProjectJsonFile from './getProjectJsonFile/index.js';
 import getPackageVersion from './getPackageVersion/index.js';
-import createDirectoryIfNotExists from './createDirectoryIfNotExists/index.js';
 
 export {
-  createDirectoryIfNotExists,
   copyDirectory,
   debug,
   exec,


### PR DESCRIPTION
### Description:

In this pull request, we have implemented a new feature named Clean Output Mode. This feature allows users to activate a mode where all CLI logs are printed without any styling, i.e., without colors or icons.

This feature is especially useful for clients intending to use Vulcan in the background, where stylized console output may be less desirable or could even cause viewing issues.

To activate this mode, users should set the environment variable CLEAN_OUTPUT_MODE to true when running the CLI.

Here are the key points of this update:

- Added check for CLEAN_OUTPUT_MODE environment variable at the start of the script.
- Modified the feedback object to use console.log for all logging methods when CLEAN_OUTPUT_MODE is set to true.
- Updated JSDoc documentation to reflect these changes.

This feature enhances the flexibility of our CLI by allowing users to customize log output according to their specific needs.


https://github.com/aziontech/vulcan/assets/12740219/139cc25a-7fdf-487b-bffa-22b616470cc3

