### PR TITLE
fix(preset-vitepress): handle lstat exception

### DIFF
--- a/lib/presets/vitepress/deliver/prebuild.js
+++ b/lib/presets/vitepress/deliver/prebuild.js
@@ -4,6 +4,19 @@ import { exec, getPackageManager, copyDirectory } from '#utils';
 const packageManager = await getPackageManager();
 
 /**
+ * Check if the project uses the "/docs"
+ * @returns {boolean} True if the structure is being used, false otherwise.
+ */
+async function docsFolderExists() {
+  try {
+    await lstat('docs/');
+    return true;
+  } catch (err) {
+    return false;
+  }
+}
+
+/**
  * Runs custom prebuild actions
  */
 async function prebuild() {
@@ -11,7 +24,7 @@ async function prebuild() {
 
   // The main folder for VitePress usually is 'docs',
   // however the users also might use the root folder
-  const outDir = (await lstat('docs/'))
+  const outDir = (await docsFolderExists())
     ? 'docs/.vitepress/dist'
     : '.vitepress/dist';
 


### PR DESCRIPTION
The 'lstat' command might raise exception, so we must handle it.