### PR TITLE
fix: merge azion.config user with preset azion.config

### DIFF
--- a/lib/build/dispatcher/dispatcher.js
+++ b/lib/build/dispatcher/dispatcher.js
@@ -1,4 +1,5 @@
 import { join } from 'path';
+import lodash from 'lodash';
 import { readFileSync, existsSync, writeFileSync, rmSync } from 'fs';
 import { Esbuild, Webpack } from '#bundlers';
 import {
@@ -526,25 +527,47 @@ class Dispatcher {
         }
       }
       // manifest
+      // azion.config.js preset
+      const presetAzionConfigPath = join(
+        this.vulcanLibPath,
+        'presets',
+        this.preset.name,
+        'azion.config.js',
+      );
+      const presetConfigModule = await vulcan.loadAzionConfig(
+        presetAzionConfigPath,
+      );
+      // azion.config.js project user
       const azionConfigPath = await vulcan.getAzionConfigPath();
-      let configModule = await vulcan.loadAzionConfig(azionConfigPath);
+      const azionConfigModule = await vulcan.loadAzionConfig(azionConfigPath);
 
-      if (!configModule) {
-        const presetAzionConfigPath = join(
-          this.vulcanLibPath,
-          'presets',
-          this.preset.name,
-          'azion.config.js',
-        );
-        configModule = await vulcan.loadAzionConfig(presetAzionConfigPath);
-
-        if (configModule) {
-          await vulcan.createAzionConfigFile(isCommonJS(), configModule);
-        }
+      if (!presetConfigModule) {
+        throw new Error(Messages.errors.azion_config_not_found);
       }
 
+      // merge azion.config.js user with preset azion.config.js
+      const customizer = (objValue, srcValue) => {
+        if (Array.isArray(objValue)) {
+          const map = new Map();
+          objValue.concat(srcValue).forEach((item) => {
+            if (item && item.name) {
+              map.set(item.name, item);
+            }
+          });
+          return Array.from(map.values());
+        }
+        return undefined;
+      };
+      // priority to user config
+      const configModule = lodash.mergeWith(
+        {},
+        presetConfigModule,
+        azionConfigModule,
+        customizer,
+      );
+
       if (!configModule) {
-        throw new Error(Messages.errors.azion_config_not_found);
+        await vulcan.createAzionConfigFile(isCommonJS(), configModule);
       }
 
       const outputPath = join(process.cwd(), '.edge');

--- a/lib/constants/messages/build.messages.js
+++ b/lib/constants/messages/build.messages.js
@@ -6,7 +6,7 @@ Build messages object.
  */
 const build = {
   success: {
-    prebuild_succeeded: 'Preb-uild succeeded!',
+    prebuild_succeeded: 'Pre-build succeeded!',
     vulcan_build_succeeded: 'Build completed!',
     manifest_succeeded: 'Azion Manifest generated successfully!',
   },


### PR DESCRIPTION
### Merge Azion Config

This PR refactors the code in the Dispatcher class to merge the user's`azion.config.js` file with the preset `azion.config.js` file. It uses the `lodash.mergeWith` function to combine the two configurations, giving priority to the user's config. This ensures that the final `configModule` used in the code is a merged version of the two configurations.

### Bonus

Fix: Typo in pre-build success message