### PR TITLE
feat: add FetchEventContext class to handle event initialization and args loading

### DIFF
--- a/lib/env/polyfills/azion/fetch-event/context/fetch-event.context.js
+++ b/lib/env/polyfills/azion/fetch-event/context/fetch-event.context.js
@@ -1,9 +1,21 @@
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
 import primitives from '@edge-runtime/primitives';
 import { feedback } from '#utils';
 
 class FetchEventContext extends primitives.FetchEvent {
-  constructor(request) {
-    super(request);
+  constructor(type, eventInitDict) {
+    super(type, eventInitDict);
+    const argsPathEnv = globalThis.vulcan.argsPath || 'azion/args.json';
+    const argsPath = join(process.cwd(), argsPathEnv);
+    if (existsSync(argsPath)) {
+      try {
+        const args = JSON.parse(readFileSync(argsPath, 'utf8'));
+        this.args = args || {};
+      } catch (error) {
+        feedback.server.error(`Error reading args.json: ${error.message}`);
+      }
+    }
     this.console = {
       log: (log) => feedback.server.log(log),
     };

--- a/lib/main.js
+++ b/lib/main.js
@@ -85,6 +85,7 @@ function setVulcanEnvironment() {
     version: vulcanVersion,
     buildProd: true,
     tempPath: createProjectTempPath(),
+    argsPath: `azion/args.json`,
   };
 
   const AZION_ENV = process.env.AZION_ENV || vulcanContext.env;


### PR DESCRIPTION
FetchEventContext class to handle event initialization and args loading

The args file path was set in `globalThis.vulcan.argsPath`