### PR TITLE
fix: adding the config build preset when creating azion.config

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,5 +1,7 @@
 {
   "compilerOptions": {
+    "moduleResolution": "Bundler",
+    "module": "ESNext",
     "baseUrl": "./",
     "paths": {
       "#root/*": ["./"],
@@ -14,7 +16,6 @@
       "#env": ["./lib/env/index.js"],
       "#platform": ["./lib/platform/index.js"],
       "#constants": ["./lib/constants/index.js"],
-      "#edge": ["./lib/env/edgehooks/index.js"],
       "#commands": ["./lib/commands/index.js"]
     }
   }

--- a/lib/commands/build.commands.js
+++ b/lib/commands/build.commands.js
@@ -119,10 +119,18 @@ async function buildCommand(
       customConfigurationModule?.preset,
       preset,
       vulcanVariables,
-      { name: 'javascript' },
+      { name: '' },
     ),
     custom: customConfigurationModule?.custom ?? {},
   };
+
+  // If no preset is provided, use the default preset.
+  if (config.preset.name === '') {
+    config.preset.name = 'javascript';
+    feedback.warn(
+      'No preset provided. Using the default preset: javascript. Or you can provide a preset using the --preset argument.',
+    );
+  }
 
   if (
     config.preset.name === 'javascript' ||

--- a/lib/presets/angular/azion.config.js
+++ b/lib/presets/angular/azion.config.js
@@ -1,6 +1,11 @@
 import { defineConfig } from 'azion';
 
 const config = defineConfig({
+  build: {
+    preset: {
+      name: 'angular',
+    },
+  },
   origin: [
     {
       name: 'origin-storage-default',

--- a/lib/presets/astro/azion.config.js
+++ b/lib/presets/astro/azion.config.js
@@ -1,6 +1,11 @@
 import { defineConfig } from 'azion';
 
 const config = defineConfig({
+  build: {
+    preset: {
+      name: 'astro',
+    },
+  },
   origin: [
     {
       name: 'origin-storage-default',

--- a/lib/presets/docusaurus/azion.config.js
+++ b/lib/presets/docusaurus/azion.config.js
@@ -1,6 +1,11 @@
 import { defineConfig } from 'azion';
 
 const config = defineConfig({
+  build: {
+    preset: {
+      name: 'docusaurus',
+    },
+  },
   origin: [
     {
       name: 'origin-storage-default',

--- a/lib/presets/eleventy/azion.config.js
+++ b/lib/presets/eleventy/azion.config.js
@@ -1,6 +1,11 @@
 import { defineConfig } from 'azion';
 
 const config = defineConfig({
+  build: {
+    preset: {
+      name: 'eleventy',
+    },
+  },
   origin: [
     {
       name: 'origin-storage-default',

--- a/lib/presets/emscripten/azion.config.js
+++ b/lib/presets/emscripten/azion.config.js
@@ -1,6 +1,11 @@
 import { defineConfig } from 'azion';
 
 const config = defineConfig({
+  build: {
+    preset: {
+      name: 'emscripten',
+    },
+  },
   rules: {
     request: [
       {

--- a/lib/presets/gatsby/azion.config.js
+++ b/lib/presets/gatsby/azion.config.js
@@ -1,6 +1,11 @@
 import { defineConfig } from 'azion';
 
 export default defineConfig({
+  build: {
+    preset: {
+      name: 'gatsby',
+    },
+  },
   origin: [
     {
       name: 'origin-storage-default',

--- a/lib/presets/hexo/azion.config.js
+++ b/lib/presets/hexo/azion.config.js
@@ -1,6 +1,11 @@
 import { defineConfig } from 'azion';
 
 export default defineConfig({
+  build: {
+    preset: {
+      name: 'hexo',
+    },
+  },
   origin: [
     {
       name: 'origin-storage-default',

--- a/lib/presets/html/azion.config.js
+++ b/lib/presets/html/azion.config.js
@@ -1,6 +1,11 @@
 import { defineConfig } from 'azion';
 
 export default defineConfig({
+  build: {
+    preset: {
+      name: 'html',
+    },
+  },
   origin: [
     {
       name: 'origin-storage-default',

--- a/lib/presets/hugo/azion.config.js
+++ b/lib/presets/hugo/azion.config.js
@@ -1,6 +1,11 @@
 import { defineConfig } from 'azion';
 
 export default defineConfig({
+  build: {
+    preset: {
+      name: 'hugo',
+    },
+  },
   origin: [
     {
       name: 'origin-storage-default',

--- a/lib/presets/javascript/azion.config.js
+++ b/lib/presets/javascript/azion.config.js
@@ -1,6 +1,11 @@
 import { defineConfig } from 'azion';
 
 export default defineConfig({
+  build: {
+    preset: {
+      name: 'javascript',
+    },
+  },
   rules: {
     request: [
       {

--- a/lib/presets/jekyll/azion.config.js
+++ b/lib/presets/jekyll/azion.config.js
@@ -1,6 +1,11 @@
 import { defineConfig } from 'azion';
 
 export default defineConfig({
+  build: {
+    preset: {
+      name: 'jekyll',
+    },
+  },
   origin: [
     {
       name: 'origin-storage-default',

--- a/lib/presets/next/azion.config.js
+++ b/lib/presets/next/azion.config.js
@@ -1,6 +1,11 @@
 import { defineConfig } from 'azion';
 
 export default defineConfig({
+  build: {
+    preset: {
+      name: 'next',
+    },
+  },
   origin: [
     {
       name: 'origin-storage-default',

--- a/lib/presets/react/azion.config.js
+++ b/lib/presets/react/azion.config.js
@@ -1,6 +1,11 @@
 import { defineConfig } from 'azion';
 
 export default defineConfig({
+  build: {
+    preset: {
+      name: 'react',
+    },
+  },
   origin: [
     {
       name: 'origin-storage-default',

--- a/lib/presets/rustwasm/azion.config.js
+++ b/lib/presets/rustwasm/azion.config.js
@@ -1,6 +1,11 @@
 import { defineConfig } from 'azion';
 
 export default defineConfig({
+  build: {
+    preset: {
+      name: 'rustwasm',
+    },
+  },
   rules: {
     request: [
       {

--- a/lib/presets/svelte/azion.config.js
+++ b/lib/presets/svelte/azion.config.js
@@ -1,6 +1,11 @@
 import { defineConfig } from 'azion';
 
 export default defineConfig({
+  build: {
+    preset: {
+      name: 'svelte',
+    },
+  },
   origin: [
     {
       name: 'origin-storage-default',

--- a/lib/presets/typescript/azion.config.js
+++ b/lib/presets/typescript/azion.config.js
@@ -1,6 +1,11 @@
 import { defineConfig } from 'azion';
 
 export default defineConfig({
+  build: {
+    preset: {
+      name: 'typescript',
+    },
+  },
   rules: {
     request: [
       {

--- a/lib/presets/vitepress/azion.config.js
+++ b/lib/presets/vitepress/azion.config.js
@@ -1,6 +1,11 @@
 import { defineConfig } from 'azion';
 
 export default defineConfig({
+  build: {
+    preset: {
+      name: 'vitepress',
+    },
+  },
   origin: [
     {
       name: 'origin-storage-default',

--- a/lib/presets/vue/azion.config.js
+++ b/lib/presets/vue/azion.config.js
@@ -1,6 +1,11 @@
 import { defineConfig } from 'azion';
 
 export default defineConfig({
+  build: {
+    preset: {
+      name: 'vue',
+    },
+  },
   origin: [
     {
       name: 'origin-storage-default',

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "ajv-errors": "^3.0.0",
     "ajv-keywords": "^5.1.0",
     "assert": "^2.0.0",
-    "azion": "^1.8.0",
+    "azion": "^1.8.2",
     "bottleneck": "^2.19.5",
     "browserify-zlib": "^0.2.0",
     "buffer": "^6.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -966,9 +966,9 @@
     "@jridgewell/trace-mapping" "^0.3.9"
 
 "@jridgewell/sourcemap-codec@^1.4.10", "@jridgewell/sourcemap-codec@^1.4.14":
-  version "1.4.15"
-  resolved "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz"
-  integrity sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==
+  version "1.5.0"
+  resolved "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz"
+  integrity sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==
 
 "@jridgewell/trace-mapping@^0.3.12", "@jridgewell/trace-mapping@^0.3.17", "@jridgewell/trace-mapping@^0.3.18", "@jridgewell/trace-mapping@^0.3.9":
   version "0.3.20"
@@ -1316,7 +1316,7 @@
 
 "@puppeteer/browsers@2.4.0":
   version "2.4.0"
-  resolved "https://registry.yarnpkg.com/@puppeteer/browsers/-/browsers-2.4.0.tgz#a0dd0f4e381e53f509109ae83b891db5972750f5"
+  resolved "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.4.0.tgz"
   integrity sha512-x8J1csfIygOwf6D6qUAZ0ASk3z63zPb7wkNeHRerCMh82qWKUrOgkuP005AJC8lDL6/evtXETGEJVcwykKT4/g==
   dependencies:
     debug "^4.3.6"
@@ -2115,9 +2115,9 @@ ansi-regex@^5.0.1:
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
 
 ansi-regex@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz"
-  integrity sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==
+  version "6.1.0"
+  resolved "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz"
+  integrity sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==
 
 ansi-styles@^3.2.1:
   version "3.2.1"
@@ -2336,10 +2336,10 @@ axios@^1.6.1:
     form-data "^4.0.0"
     proxy-from-env "^1.1.0"
 
-azion@^1.8.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/azion/-/azion-1.8.0.tgz#0894198a550498e122d26e1c7a94bc00c0cc5b21"
-  integrity sha512-DKchIl2nGzZCtXp9HZmnlBpUdBZmnQgnkiMGaPP7CEyv7sXQRCFj9ITflyveLVsJi37D4oUtLYzR1BIu9tP1Xg==
+azion@^1.8.2:
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/azion/-/azion-1.8.2.tgz#fd024dc6c0ef49c90b49a497d485d652e72215ef"
+  integrity sha512-TRueU0w9JG4PYCYw0eWU069UvByU8tXEEVLryrOsCMzQ2Nn6x33VdiJAMOuE8FP31BmF2wyVdfITKTkEBy+dwg==
   dependencies:
     chalk "^5.3.0"
     progress "^2.0.3"
@@ -2351,7 +2351,7 @@ b4a@^1.6.4:
 
 b4a@^1.6.6:
   version "1.6.6"
-  resolved "https://registry.yarnpkg.com/b4a/-/b4a-1.6.6.tgz#a4cc349a3851987c3c4ac2d7785c18744f6da9ba"
+  resolved "https://registry.npmjs.org/b4a/-/b4a-1.6.6.tgz"
   integrity sha512-5Tk1HLk6b6ctmjIkAcU/Ujv/1WqiDl0F0JdRCR80VsOcUlHcu7pWeWRlOqQLHfDEsVx9YH/aif5AG4ehoCtTmg==
 
 babel-jest@^29.7.0:
@@ -2421,12 +2421,12 @@ balanced-match@^1.0.0:
 
 bare-events@^2.0.0, bare-events@^2.2.0:
   version "2.4.2"
-  resolved "https://registry.yarnpkg.com/bare-events/-/bare-events-2.4.2.tgz#3140cca7a0e11d49b3edc5041ab560659fd8e1f8"
+  resolved "https://registry.npmjs.org/bare-events/-/bare-events-2.4.2.tgz"
   integrity sha512-qMKFd2qG/36aA4GwvKq8MxnPgCQAmBWmSyLWsJcbn8v03wvIPQ/hG1Ms8bPzndZxMDoHpxez5VOS+gC9Yi24/Q==
 
 bare-fs@^2.1.1:
   version "2.3.5"
-  resolved "https://registry.yarnpkg.com/bare-fs/-/bare-fs-2.3.5.tgz#05daa8e8206aeb46d13c2fe25a2cd3797b0d284a"
+  resolved "https://registry.npmjs.org/bare-fs/-/bare-fs-2.3.5.tgz"
   integrity sha512-SlE9eTxifPDJrT6YgemQ1WGFleevzwY+XAP1Xqgl56HtcrisC2CHCZ2tq6dBpcH2TnNxwUEUGhweo+lrQtYuiw==
   dependencies:
     bare-events "^2.0.0"
@@ -2435,19 +2435,19 @@ bare-fs@^2.1.1:
 
 bare-os@^2.1.0:
   version "2.4.4"
-  resolved "https://registry.yarnpkg.com/bare-os/-/bare-os-2.4.4.tgz#01243392eb0a6e947177bb7c8a45123d45c9b1a9"
+  resolved "https://registry.npmjs.org/bare-os/-/bare-os-2.4.4.tgz"
   integrity sha512-z3UiI2yi1mK0sXeRdc4O1Kk8aOa/e+FNWZcTiPB/dfTWyLypuE99LibgRaQki914Jq//yAWylcAt+mknKdixRQ==
 
 bare-path@^2.0.0, bare-path@^2.1.0:
   version "2.1.3"
-  resolved "https://registry.yarnpkg.com/bare-path/-/bare-path-2.1.3.tgz#594104c829ef660e43b5589ec8daef7df6cedb3e"
+  resolved "https://registry.npmjs.org/bare-path/-/bare-path-2.1.3.tgz"
   integrity sha512-lh/eITfU8hrj9Ru5quUp0Io1kJWIk1bTjzo7JH1P5dWmQ2EL4hFUlfI8FonAhSlgIfhn63p84CDY/x+PisgcXA==
   dependencies:
     bare-os "^2.1.0"
 
 bare-stream@^2.0.0:
   version "2.3.0"
-  resolved "https://registry.yarnpkg.com/bare-stream/-/bare-stream-2.3.0.tgz#5bef1cab8222517315fca1385bd7f08dff57f435"
+  resolved "https://registry.npmjs.org/bare-stream/-/bare-stream-2.3.0.tgz"
   integrity sha512-pVRWciewGUeCyKEuRxwv06M079r+fRjAQjBEK2P6OYGrO43O+Z0LrPZZEjlc4mB6C2RpZ9AxJ1s7NLEtOHO6eA==
   dependencies:
     b4a "^1.6.6"
@@ -2841,7 +2841,7 @@ chrome-trace-event@^1.0.2:
 
 chromium-bidi@0.6.5:
   version "0.6.5"
-  resolved "https://registry.yarnpkg.com/chromium-bidi/-/chromium-bidi-0.6.5.tgz#31be98f9ee5c93fa99d240c680518c9293d8c6bb"
+  resolved "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.6.5.tgz"
   integrity sha512-RuLrmzYrxSb0s9SgpB+QN5jJucPduZQ/9SIe76MDxYJuecPW5mxMdacJ1f4EtgiV+R0p3sCkznTMvH0MPGFqjA==
   dependencies:
     mitt "3.0.1"
@@ -3215,7 +3215,7 @@ cosmiconfig@^8.0.0, cosmiconfig@^8.3.6:
 
 cosmiconfig@^9.0.0:
   version "9.0.0"
-  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-9.0.0.tgz#34c3fc58287b915f3ae905ab6dc3de258b55ad9d"
+  resolved "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz"
   integrity sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==
   dependencies:
     env-paths "^2.2.1"
@@ -3344,7 +3344,7 @@ debug@^3.2.7:
 
 debug@^4.3.6:
   version "4.3.7"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.7.tgz#87945b4151a011d76d95a198d7111c865c360a52"
+  resolved "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz"
   integrity sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==
   dependencies:
     ms "^2.1.3"
@@ -3469,7 +3469,7 @@ detect-newline@^3.0.0:
 
 devtools-protocol@0.0.1330662:
   version "0.0.1330662"
-  resolved "https://registry.yarnpkg.com/devtools-protocol/-/devtools-protocol-0.0.1330662.tgz#400fe703c2820d6b2d9ebdd1785934310152373e"
+  resolved "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1330662.tgz"
   integrity sha512-pzh6YQ8zZfz3iKlCvgzVCu22NdpZ8hNmwU6WnQjNVquh0A9iVosPtNLWDwaWVGyrntQlltPFztTMK5Cg6lfCuw==
 
 dezalgo@^1.0.4:
@@ -3703,9 +3703,9 @@ es-abstract@^1.22.1:
     which-typed-array "^1.1.13"
 
 es-module-lexer@^1.2.1:
-  version "1.4.1"
-  resolved "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.4.1.tgz"
-  integrity sha512-cXLGjP0c4T3flZJKQSuziYoq7MlT+rnvfZjfp7h+I7K9BNX54kP9nyWvdbwjQ4u1iWbOL4u96fgeZLToQlZC7w==
+  version "1.5.4"
+  resolved "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.5.4.tgz"
+  integrity sha512-MVNK56NiMrOwitFB7cqDwq0CQutbw+0BvLshJSse0MUNU+y1FC3bUS/AQg7oUng+/wKrrki7JfmwtVHkVfPLlw==
 
 es-set-tostringtag@^2.0.1:
   version "2.0.2"
@@ -4099,7 +4099,7 @@ external-editor@^3.1.0:
 
 extract-zip@^2.0.1:
   version "2.0.1"
-  resolved "https://registry.yarnpkg.com/extract-zip/-/extract-zip-2.0.1.tgz#663dca56fe46df890d5f131ef4a06d22bb8ba13a"
+  resolved "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz"
   integrity sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==
   dependencies:
     debug "^4.1.1"
@@ -4847,7 +4847,7 @@ http-proxy-agent@^7.0.0:
 
 http-proxy-agent@^7.0.1:
   version "7.0.2"
-  resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz#9a8b1f246866c028509486585f62b8f2c18c270e"
+  resolved "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz"
   integrity sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==
   dependencies:
     agent-base "^7.1.0"
@@ -4876,7 +4876,7 @@ https-proxy-agent@^7.0.0, https-proxy-agent@^7.0.2:
 
 https-proxy-agent@^7.0.3:
   version "7.0.5"
-  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-7.0.5.tgz#9e8b5013873299e11fab6fd548405da2d6c602b2"
+  resolved "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.5.tgz"
   integrity sha512-1e4Wqeblerz+tMKPIq2EMGiiWW1dIjZOksyHWSUm1rmuvw/how9hBHZ38lAGj5ID4Ik6EdkOw7NmWPy6LAwalw==
   dependencies:
     agent-base "^7.0.2"
@@ -7338,9 +7338,9 @@ pac-resolver@^7.0.0:
     netmask "^2.0.2"
 
 package-json-from-dist@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/package-json-from-dist/-/package-json-from-dist-1.0.0.tgz#e501cd3094b278495eb4258d4c9f6d5ac3019f00"
-  integrity sha512-dATvCeZN/8wQsGywez1mzHtTlP22H8OEfPrVMLNr4/eGa+ijtLn/6M5f0dY8UKNrC2O9UCU6SSoG3qRKnt7STw==
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz#4f1471a010827a86f94cfd9b0727e36d267de505"
+  integrity sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==
 
 pacote@^15.0.0, pacote@^15.0.8, pacote@^15.2.0:
   version "15.2.0"
@@ -7632,7 +7632,7 @@ process@^0.11.10:
 
 progress@^2.0.3:
   version "2.0.3"
-  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
+  resolved "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
 
 promise-all-reject-late@^1.0.0:
@@ -7680,7 +7680,7 @@ proto-list@~1.2.1:
 
 proxy-agent@^6.4.0:
   version "6.4.0"
-  resolved "https://registry.yarnpkg.com/proxy-agent/-/proxy-agent-6.4.0.tgz#b4e2dd51dee2b377748aef8d45604c2d7608652d"
+  resolved "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.4.0.tgz"
   integrity sha512-u0piLU+nCOHMgGjRbimiXmA9kM/L9EHh3zL81xCdp7m+Y2pHIsnmbdDoEDoAz5geaonNR6q6+yOPQs6n4T6sBQ==
   dependencies:
     agent-base "^7.0.2"
@@ -7729,7 +7729,7 @@ punycode@^2.1.0:
 
 puppeteer-core@23.3.0:
   version "23.3.0"
-  resolved "https://registry.yarnpkg.com/puppeteer-core/-/puppeteer-core-23.3.0.tgz#e9e7367367e230ab3ed0b6b674170b09ba0a96e3"
+  resolved "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-23.3.0.tgz"
   integrity sha512-sB2SsVMFs4gKad5OCdv6w5vocvtEUrRl0zQqSyRPbo/cj1Ktbarmhxy02Zyb9R9HrssBcJDZbkrvBnbaesPyYg==
   dependencies:
     "@puppeteer/browsers" "2.4.0"
@@ -7741,7 +7741,7 @@ puppeteer-core@23.3.0:
 
 puppeteer@^23.3.0:
   version "23.3.0"
-  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-23.3.0.tgz#f2a3b28c05c17504adf1a903247e01f93e27d6b5"
+  resolved "https://registry.npmjs.org/puppeteer/-/puppeteer-23.3.0.tgz"
   integrity sha512-e2jY8cdWSUGsrLxqGm3hIbJq/UIk1uOY8XY7SM51leXkH7shrIyE91lK90Q9byX6tte+cyL3HKqlWBEd6TjWTA==
   dependencies:
     "@puppeteer/browsers" "2.4.0"
@@ -8205,7 +8205,7 @@ semver@^6.3.0, semver@^6.3.1:
 
 semver@^7.6.3:
   version "7.6.3"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.3.tgz#980f7b5550bc175fb4dc09403085627f9eb33143"
+  resolved "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz"
   integrity sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==
 
 serialize-javascript@^6.0.1:
@@ -8529,7 +8529,7 @@ streamx@^2.15.0:
 
 streamx@^2.20.0:
   version "2.20.1"
-  resolved "https://registry.yarnpkg.com/streamx/-/streamx-2.20.1.tgz#471c4f8b860f7b696feb83d5b125caab2fdbb93c"
+  resolved "https://registry.npmjs.org/streamx/-/streamx-2.20.1.tgz"
   integrity sha512-uTa0mU6WUC65iUvzKH4X9hEdvSW7rbPxPtwfWiLMSj3qTdQbAiUboZTxauKfpFuGIGa1C2BYijZ7wgdUXICJhA==
   dependencies:
     fast-fifo "^1.3.2"
@@ -8734,7 +8734,7 @@ tapable@^2.1.1, tapable@^2.2.0:
 
 tar-fs@^3.0.6:
   version "3.0.6"
-  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-3.0.6.tgz#eaccd3a67d5672f09ca8e8f9c3d2b89fa173f217"
+  resolved "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.6.tgz"
   integrity sha512-iokBDQQkUyeXhgPYaZxmczGPhnhXZ0CmrqI+MOb/WFGS9DW5wnfrLgtjUJBvz50vQ3qfRwJ62QVoCFu8mPVu5w==
   dependencies:
     pump "^3.0.0"
@@ -8811,7 +8811,7 @@ test-exclude@^6.0.0:
 
 text-decoder@^1.1.0:
   version "1.2.0"
-  resolved "https://registry.yarnpkg.com/text-decoder/-/text-decoder-1.2.0.tgz#85f19d4d5088e0b45cd841bdfaeac458dbffeefc"
+  resolved "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.0.tgz"
   integrity sha512-n1yg1mOj9DNpk3NeZOx7T6jchTbyJS3i3cucbNN6FcdPriMZx7NsgrGpWWdWZZGxD7ES1XB+3uoqHMgOKaN+fg==
   dependencies:
     b4a "^1.6.4"
@@ -9071,7 +9071,7 @@ typed-array-length@^1.0.4:
 
 typed-query-selector@^2.12.0:
   version "2.12.0"
-  resolved "https://registry.yarnpkg.com/typed-query-selector/-/typed-query-selector-2.12.0.tgz#92b65dbc0a42655fccf4aeb1a08b1dddce8af5f2"
+  resolved "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.0.tgz"
   integrity sha512-SbklCd1F0EiZOyPiW192rrHZzZ5sBijB6xM+cpmrwDqObvdtunOHHIk9fCGsoK5JVIYXoyEp4iEdE3upFH3PAg==
 
 typescript@^5.5.3:
@@ -9101,7 +9101,7 @@ unbox-primitive@^1.0.2:
 
 unbzip2-stream@^1.4.3:
   version "1.4.3"
-  resolved "https://registry.yarnpkg.com/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz#b0da04c4371311df771cdc215e87f2130991ace7"
+  resolved "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz"
   integrity sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==
   dependencies:
     buffer "^5.2.1"
@@ -9207,7 +9207,7 @@ url@^0.11.1:
 
 urlpattern-polyfill@10.0.0:
   version "10.0.0"
-  resolved "https://registry.yarnpkg.com/urlpattern-polyfill/-/urlpattern-polyfill-10.0.0.tgz#f0a03a97bfb03cdf33553e5e79a2aadd22cac8ec"
+  resolved "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.0.0.tgz"
   integrity sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg==
 
 util-deprecate@^1.0.1, util-deprecate@^1.0.2, util-deprecate@~1.0.1:
@@ -9447,7 +9447,7 @@ write-file-atomic@^5.0.0, write-file-atomic@^5.0.1:
 
 ws@^8.18.0:
   version "8.18.0"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.0.tgz#0d7505a6eafe2b0e712d232b42279f53bc289bbc"
+  resolved "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz"
   integrity sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==
 
 xmlcreate@^2.0.4:
@@ -9518,5 +9518,5 @@ yocto-queue@^1.0.0:
 
 zod@3.23.8:
   version "3.23.8"
-  resolved "https://registry.yarnpkg.com/zod/-/zod-3.23.8.tgz#e37b957b5d52079769fb8097099b592f0ef4067d"
+  resolved "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz"
   integrity sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==


### PR DESCRIPTION
Adding the build preset config to the presets azion.config.js so that it is
inserted when the file is created when it does not exist in the user's project.

### Bonus

- Update Azion dependency to version 1.8.2
- Inserting warning message when preset is missing