### PR TITLE
fix: update error message for invalid build preset

### DIFF
--- a/lib/build/dispatcher/dispatcher.js
+++ b/lib/build/dispatcher/dispatcher.js
@@ -127,7 +127,9 @@ class Dispatcher {
     const validPreset = VALID_BUILD_PRESETS.includes(this.preset.name);
 
     if (!validPreset) {
-      feedback.build.error(Messages.build.error.invalid_preset);
+      feedback.build.error(
+        Messages.build.error.invalid_preset(this.preset.name),
+      );
       process.exit(1);
     }
 

--- a/lib/build/dispatcher/dispatcher.js
+++ b/lib/build/dispatcher/dispatcher.js
@@ -123,12 +123,14 @@ class Dispatcher {
    */
   async loadPreset() {
     const VALID_BUILD_PRESETS = presets.getKeys();
-
+    const originalPresetName = this.preset.name;
+    // e.g. accept 'javascript' and 'JavaScript'
+    this.preset.name = this.preset.name.toLowerCase();
     const validPreset = VALID_BUILD_PRESETS.includes(this.preset.name);
 
     if (!validPreset) {
       feedback.build.error(
-        Messages.build.error.invalid_preset(this.preset.name),
+        Messages.build.error.invalid_preset(originalPresetName),
       );
       process.exit(1);
     }

--- a/lib/constants/messages/build.messages.js
+++ b/lib/constants/messages/build.messages.js
@@ -17,8 +17,8 @@ const build = {
   },
   error: {
     vulcan_build_failed: 'Azion build failed.',
-    invalid_preset:
-      'Invalid build preset. Run "azion preset ls" to view available presets.',
+    invalid_preset: (preset) =>
+      `Invalid build preset name: '${preset}'. Run "npx edge-functions presets ls" to view available presets.`,
     invalid_preset_mode: (mode, preset) =>
       `Mode '${mode}' does not exists in preset '${preset}'. Try 'deliver' or 'compute'.`,
     prebuild_error_validation_support: (framework, version, runtimes) =>


### PR DESCRIPTION
- Entering invalid preset name in error message.
- Changing the command to list presets in the error message from `azion presets ls` to `npx edge-functions presets ls`.
  
<img width="1004" alt="Screenshot 2024-10-14 at 12 53 36" src="https://github.com/user-attachments/assets/ea9352e5-da6c-4d13-b41e-ea28683fab51">
