### PR TITLE
fix: removing the import of the azion package when creating the azion.config

### DIFF
--- a/lib/env/vulcan.env.js
+++ b/lib/env/vulcan.env.js
@@ -271,7 +271,7 @@ async function createAzionConfigFile(useCommonJS, module) {
   );
 
   const formattedContent = await prettier.format(
-    `${moduleExportStyle} defineConfig(${jsonString});`,
+    `${moduleExportStyle} ${jsonString};`,
     {
       parser: 'babel',
       semi: false,
@@ -280,11 +280,7 @@ async function createAzionConfigFile(useCommonJS, module) {
     },
   );
 
-  const importStatement = useCommonJS
-    ? "const { defineConfig } = require('azion');\n\n"
-    : "import { defineConfig } from 'azion';\n\n";
-
-  const finalContent = `${importStatement}${formattedContent}`;
+  const finalContent = `${formattedContent}`;
 
   if (!fs.existsSync(configPath)) {
     await fsPromises.writeFile(configPath, finalContent);


### PR DESCRIPTION
We are removing the import of the azion package when creating the azion.config for use with defineConfig.
This is to make the installation of the package no longer mandatory.