### PR TITLE
fix: removing the need to pass the preset flag when js

### DIFF
--- a/lib/commands/build.commands.js
+++ b/lib/commands/build.commands.js
@@ -1,5 +1,5 @@
 import { Commands } from '#namespaces';
-import { feedback } from '#utils';
+import { checkingProjectTypeJS, feedback } from '#utils';
 import vulcan from '../env/vulcan.env.js';
 
 /**
@@ -54,7 +54,7 @@ function getPresetValue(
  * @param {object} options - Configuration options for the build command.
  * @param {string} [options.entry] - The entry point file for the build.
  * @param {string} [options.builder] - The name of the Bundler you want to use (Esbuild or Webpack)
- * @param {string} [options.preset] - Preset to be used (e.g., 'javascript', 'typescript').
+ * @param {string} [options.preset] - Preset to be used (e.g., 'javascript').
  * @param {boolean} [options.polyfills] - Whether to use Node.js polyfills.
  * @param {boolean} [options.worker] - This flag indicates that the constructed code inserts its own worker expression, such as addEventListener("fetch") or similar, without the need to inject a provider.
  * @param {boolean} [options.onlyManifest] - Skip build and process. just the manifest.
@@ -81,7 +81,7 @@ async function buildCommand(
       customConfigurationModule?.entry,
       entry,
       vulcanVariables?.entry,
-      preset === 'typescript' ? './main.ts' : './main.js',
+      (await checkingProjectTypeJS()) ? './main.ts' : './main.js',
     ),
     builder: getConfigValue(
       customConfigurationModule?.builder,
@@ -126,9 +126,9 @@ async function buildCommand(
 
   // If no preset is provided, use the default preset.
   if (config.preset.name === '') {
-    config.preset.name = 'javascript';
+    config.preset.name = await checkingProjectTypeJS();
     feedback.warn(
-      'No preset provided. Using the default preset: javascript. Or you can provide a preset using the --preset argument.',
+      `No preset provided. Using the default preset: ${config.preset.name}. Or you can provide a preset using the --preset argument.`,
     );
   }
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -167,7 +167,10 @@ function startVulcanProgram() {
   program
     .command('build')
     .description('Build a project for edge deployment')
-    .option('--entry <string>', 'Code entrypoint (default: ./main.js)')
+    .option(
+      '--entry <string>',
+      'Code entrypoint (default: ./main.js or ./main.ts)',
+    )
     .option(
       '--preset <type>',
       'Preset of build target (e.g., vue, next, javascript)',

--- a/lib/utils/checkingProjectType/checkingProjectType.test.js
+++ b/lib/utils/checkingProjectType/checkingProjectType.test.js
@@ -1,0 +1,25 @@
+import mockFs from 'mock-fs';
+import checkingProjectTypeJS from './checkingProjectType.utils.js';
+
+describe('checkingProjectType utils', () => {
+  describe('checkingProjectTypeJS', () => {
+    it('should return the correct project type typescript', async () => {
+      mockFs({
+        'tsconfig.json': 'content',
+        'file.ts': 'content',
+      });
+      const isTypeScript = await checkingProjectTypeJS();
+      expect(isTypeScript).toBe('typescript');
+      mockFs.restore();
+    });
+
+    it('should return the correct project type javascript', async () => {
+      mockFs({
+        'file.js': 'content',
+      });
+      const isTypeScript = await checkingProjectTypeJS();
+      expect(isTypeScript).toBe('javascript');
+      mockFs.restore();
+    });
+  });
+});

--- a/lib/utils/checkingProjectType/checkingProjectType.utils.js
+++ b/lib/utils/checkingProjectType/checkingProjectType.utils.js
@@ -1,0 +1,27 @@
+import { existsSync, readdirSync } from 'fs';
+import { join, extname } from 'path';
+
+/**
+ * Checks if the project is a TypeScript or JavaScript project.
+ * @param {string} currentDir - The current directory.
+ * @returns {Promise<string>} - A promise that resolves to the project type (javascript or typescript).
+ */
+const checkingProjectTypeJS = async (currentDir = process.cwd()) => {
+  const tsConfigPath = join(currentDir, 'tsconfig.json');
+  const tsConfigExist = existsSync(tsConfigPath);
+  if (tsConfigExist) {
+    return 'typescript';
+  }
+
+  const files = readdirSync(currentDir);
+  const hasTypeScriptFiles = files.some((file) =>
+    ['.ts', '.tsx'].includes(extname(file)),
+  );
+  if (hasTypeScriptFiles) {
+    return 'typescript';
+  }
+
+  return 'javascript';
+};
+
+export default checkingProjectTypeJS;

--- a/lib/utils/checkingProjectType/index.js
+++ b/lib/utils/checkingProjectType/index.js
@@ -1,0 +1,3 @@
+import checkingProjectTypeJS from './checkingProjectType.utils.js';
+
+export default checkingProjectTypeJS;

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -21,6 +21,7 @@ import injectFilesInMem from './injectFilesInMem/index.js';
 import helperHandlerCode from './helperHandlerCode/index.js';
 import generateManifest from './generateManifest/index.js';
 import copyFilesToFS from './copyFilesToFS/index.js';
+import checkingProjectTypeJS from './checkingProjectType/index.js';
 
 export {
   copyDirectory,
@@ -46,4 +47,5 @@ export {
   helperHandlerCode,
   generateManifest,
   copyFilesToFS,
+  checkingProjectTypeJS,
 };


### PR DESCRIPTION
When the preset is JavaScript or Typescript, it is not necessary to pass the --preset flag in the build command.
It is still allowed to pass --preset javascript or typescript!