### PR TITLE
fix: incorrect file extension in build command

### DIFF
--- a/lib/commands/build.commands.js
+++ b/lib/commands/build.commands.js
@@ -81,7 +81,7 @@ async function buildCommand(
       customConfigurationModule?.entry,
       entry,
       vulcanVariables?.entry,
-      (await checkingProjectTypeJS()) ? './main.ts' : './main.js',
+      (await checkingProjectTypeJS()) ? './main.js' : './main.ts',
     ),
     builder: getConfigValue(
       customConfigurationModule?.builder,


### PR DESCRIPTION
Fixing entry file extension order when presetting javascript or typescript