### PR TITLE
test: add no-sandbox args for puppeteer launch in E2E tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine3.17 AS node
+FROM node:18.20.5-alpine3.21 AS node
 
 WORKDIR /
 

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "ajv-errors": "^3.0.0",
     "ajv-keywords": "^5.1.0",
     "assert": "^2.0.0",
-    "azion": "^1.12.0",
+    "azion": "^1.12.1",
     "babel-loader": "^9.2.1",
     "bottleneck": "^2.19.5",
     "browserify-zlib": "^0.2.0",

--- a/tests/e2e/angular-static.test.js
+++ b/tests/e2e/angular-static.test.js
@@ -25,7 +25,10 @@ describe('E2E - angular-static project', () => {
 
     await projectInitializer(EXAMPLE_PATH, 'angular', serverPort);
 
-    browser = await puppeteer.launch({ headless: 'new' });
+    browser = await puppeteer.launch({
+      args: ['--no-sandbox', '--disable-setuid-sandbox'],
+      headless: 'new',
+    });
     page = await browser.newPage();
   }, TIMEOUT);
 

--- a/tests/e2e/astro-static.test.js
+++ b/tests/e2e/astro-static.test.js
@@ -25,7 +25,10 @@ describe('E2E - astro-static project', () => {
 
     await projectInitializer(EXAMPLE_PATH, 'astro', serverPort);
 
-    browser = await puppeteer.launch({ headless: 'new' });
+    browser = await puppeteer.launch({
+      args: ['--no-sandbox', '--disable-setuid-sandbox'],
+      headless: 'new',
+    });
     page = await browser.newPage();
   }, TIMEOUT);
 

--- a/tests/e2e/docusaurus-static.test.js
+++ b/tests/e2e/docusaurus-static.test.js
@@ -20,7 +20,10 @@ describe('E2E - docusaurus project', () => {
 
     await projectInitializer(EXAMPLE_PATH, 'docusaurus', serverPort);
 
-    browser = await puppeteer.launch({ headless: 'new' });
+    browser = await puppeteer.launch({
+      args: ['--no-sandbox', '--disable-setuid-sandbox'],
+      headless: 'new',
+    });
     page = await browser.newPage();
   }, TIMEOUT);
 

--- a/tests/e2e/eleventy-static.test.js
+++ b/tests/e2e/eleventy-static.test.js
@@ -25,7 +25,10 @@ describe('E2E - eleventy-static project', () => {
 
     await projectInitializer(EXAMPLE_PATH, 'eleventy', serverPort);
 
-    browser = await puppeteer.launch({ headless: 'new' });
+    browser = await puppeteer.launch({
+      args: ['--no-sandbox', '--disable-setuid-sandbox'],
+      headless: 'new',
+    });
     page = await browser.newPage();
   }, TIMEOUT);
 

--- a/tests/e2e/gatsby-static.test.js
+++ b/tests/e2e/gatsby-static.test.js
@@ -25,7 +25,10 @@ describe('E2E - gatsby-static project', () => {
 
     await projectInitializer(EXAMPLE_PATH, 'gatsby', serverPort);
 
-    browser = await puppeteer.launch({ headless: 'new' });
+    browser = await puppeteer.launch({
+      args: ['--no-sandbox', '--disable-setuid-sandbox'],
+      headless: 'new',
+    });
     page = await browser.newPage();
   }, TIMEOUT);
 

--- a/tests/e2e/hexo-static.test.js
+++ b/tests/e2e/hexo-static.test.js
@@ -32,7 +32,10 @@ describe('E2E - hexo-static project', () => {
 
     await projectInitializer(EXAMPLE_PATH, 'hexo', serverPort);
 
-    browser = await puppeteer.launch({ headless: 'new' });
+    browser = await puppeteer.launch({
+      args: ['--no-sandbox', '--disable-setuid-sandbox'],
+      headless: 'new',
+    });
     page = await browser.newPage();
   }, TIMEOUT);
 

--- a/tests/e2e/jekyll-static.test.js
+++ b/tests/e2e/jekyll-static.test.js
@@ -21,7 +21,10 @@ describe('E2E - jekyll-static project', () => {
 
     await projectInitializer(EXAMPLE_PATH, 'jekyll', serverPort);
 
-    browser = await puppeteer.launch({ headless: 'new' });
+    browser = await puppeteer.launch({
+      args: ['--no-sandbox', '--disable-setuid-sandbox'],
+      headless: 'new',
+    });
     page = await browser.newPage();
   }, TIMEOUT);
 

--- a/tests/e2e/next-12-3-4-config.test.js
+++ b/tests/e2e/next-12-3-4-config.test.js
@@ -22,7 +22,10 @@ describe('E2E - next-12-3-4-configs project', () => {
 
     await projectInitializer(EXAMPLE_PATH, 'next', serverPort);
 
-    browser = await puppeteer.launch({ headless: 'new' });
+    browser = await puppeteer.launch({
+      args: ['--no-sandbox', '--disable-setuid-sandbox'],
+      headless: 'new',
+    });
     page = await browser.newPage();
   }, TIMEOUT);
 

--- a/tests/e2e/next-12-3-4-i18n.test.js
+++ b/tests/e2e/next-12-3-4-i18n.test.js
@@ -22,7 +22,10 @@ describe('E2E - next-12-3-4-i18n project', () => {
 
     await projectInitializer(EXAMPLE_PATH, 'next', serverPort);
 
-    browser = await puppeteer.launch({ headless: 'new' });
+    browser = await puppeteer.launch({
+      args: ['--no-sandbox', '--disable-setuid-sandbox'],
+      headless: 'new',
+    });
     page = await browser.newPage();
   }, TIMEOUT);
 

--- a/tests/e2e/next-12-3-4-middleware.test.js
+++ b/tests/e2e/next-12-3-4-middleware.test.js
@@ -22,7 +22,10 @@ describe('E2E - next-12-3-4-middleware project', () => {
 
     await projectInitializer(EXAMPLE_PATH, 'next', serverPort);
 
-    browser = await puppeteer.launch({ headless: 'new' });
+    browser = await puppeteer.launch({
+      args: ['--no-sandbox', '--disable-setuid-sandbox'],
+      headless: 'new',
+    });
     page = await browser.newPage();
     page.setDefaultNavigationTimeout(60000);
   }, TIMEOUT);

--- a/tests/e2e/next-12-static.test.js
+++ b/tests/e2e/next-12-static.test.js
@@ -25,7 +25,10 @@ describe('E2E - next-12-static project', () => {
 
     await projectInitializer(EXAMPLE_PATH, 'next', serverPort);
 
-    browser = await puppeteer.launch({ headless: 'new' });
+    browser = await puppeteer.launch({
+      args: ['--no-sandbox', '--disable-setuid-sandbox'],
+      headless: 'new',
+    });
     page = await browser.newPage();
   }, TIMEOUT);
 

--- a/tests/e2e/next-13-5-6-config.test.js
+++ b/tests/e2e/next-13-5-6-config.test.js
@@ -22,7 +22,10 @@ describe('E2E - next-13-5-6-configs project', () => {
 
     await projectInitializer(EXAMPLE_PATH, 'next', serverPort);
 
-    browser = await puppeteer.launch({ headless: 'new' });
+    browser = await puppeteer.launch({
+      args: ['--no-sandbox', '--disable-setuid-sandbox'],
+      headless: 'new',
+    });
     page = await browser.newPage();
   }, TIMEOUT);
 

--- a/tests/e2e/next-13-5-6-i18n.test.js
+++ b/tests/e2e/next-13-5-6-i18n.test.js
@@ -22,7 +22,10 @@ describe('E2E - next-13-5-6-i18n project', () => {
 
     await projectInitializer(EXAMPLE_PATH, 'next', serverPort);
 
-    browser = await puppeteer.launch({ headless: 'new' });
+    browser = await puppeteer.launch({
+      args: ['--no-sandbox', '--disable-setuid-sandbox'],
+      headless: 'new',
+    });
     page = await browser.newPage();
   }, TIMEOUT);
 

--- a/tests/e2e/next-13-5-6-middleware.test.js
+++ b/tests/e2e/next-13-5-6-middleware.test.js
@@ -22,7 +22,10 @@ describe('E2E - next-13-5-6-middleware project', () => {
 
     await projectInitializer(EXAMPLE_PATH, 'next', serverPort);
 
-    browser = await puppeteer.launch({ headless: 'new' });
+    browser = await puppeteer.launch({
+      args: ['--no-sandbox', '--disable-setuid-sandbox'],
+      headless: 'new',
+    });
     page = await browser.newPage();
     page.setDefaultNavigationTimeout(60000);
   }, TIMEOUT);

--- a/tests/e2e/next-14-2-15-middleware.test.js
+++ b/tests/e2e/next-14-2-15-middleware.test.js
@@ -22,7 +22,10 @@ describe('E2E - next-14-2-15-middleware project', () => {
 
     await projectInitializer(EXAMPLE_PATH, 'next', serverPort);
 
-    browser = await puppeteer.launch({ headless: 'new' });
+    browser = await puppeteer.launch({
+      args: ['--no-sandbox', '--disable-setuid-sandbox'],
+      headless: 'new',
+    });
     page = await browser.newPage();
     page.setDefaultNavigationTimeout(60000);
   }, TIMEOUT);

--- a/tests/e2e/next-node-pages-12-3-1-fs.test.js
+++ b/tests/e2e/next-node-pages-12-3-1-fs.test.js
@@ -26,7 +26,10 @@ describe('E2E - next-node-pages-12-3-1-fs project', () => {
 
     await projectInitializer(EXAMPLE_PATH, 'next', serverPort);
 
-    browser = await puppeteer.launch({ headless: 'new' });
+    browser = await puppeteer.launch({
+      args: ['--no-sandbox', '--disable-setuid-sandbox'],
+      headless: 'new',
+    });
     page = await browser.newPage();
   }, TIMEOUT);
 

--- a/tests/e2e/next-node-pages-12-3-1.test.js
+++ b/tests/e2e/next-node-pages-12-3-1.test.js
@@ -26,7 +26,10 @@ describe('E2E - next-node-pages-12-3-1 project', () => {
 
     await projectInitializer(EXAMPLE_PATH, 'next', serverPort);
 
-    browser = await puppeteer.launch({ headless: 'new' });
+    browser = await puppeteer.launch({
+      args: ['--no-sandbox', '--disable-setuid-sandbox'],
+      headless: 'new',
+    });
     page = await browser.newPage();
   }, TIMEOUT);
 

--- a/tests/e2e/next-static.test.js
+++ b/tests/e2e/next-static.test.js
@@ -25,7 +25,10 @@ describe('E2E - next-static project', () => {
 
     await projectInitializer(EXAMPLE_PATH, 'next', serverPort);
 
-    browser = await puppeteer.launch({ headless: 'new' });
+    browser = await puppeteer.launch({
+      args: ['--no-sandbox', '--disable-setuid-sandbox'],
+      headless: 'new',
+    });
     page = await browser.newPage();
   }, TIMEOUT);
 

--- a/tests/e2e/nuxt-static.test.js
+++ b/tests/e2e/nuxt-static.test.js
@@ -25,7 +25,10 @@ describe('E2E - nuxt-static project', () => {
 
     await projectInitializer(EXAMPLE_PATH, 'nuxt', serverPort);
 
-    browser = await puppeteer.launch({ headless: 'new' });
+    browser = await puppeteer.launch({
+      args: ['--no-sandbox', '--disable-setuid-sandbox'],
+      headless: 'new',
+    });
     page = await browser.newPage();
   }, TIMEOUT);
 

--- a/tests/e2e/react-static.test.js
+++ b/tests/e2e/react-static.test.js
@@ -25,7 +25,10 @@ describe('E2E - react-static project', () => {
 
     await projectInitializer(EXAMPLE_PATH, 'react', serverPort);
 
-    browser = await puppeteer.launch({ headless: 'new' });
+    browser = await puppeteer.launch({
+      args: ['--no-sandbox', '--disable-setuid-sandbox'],
+      headless: 'new',
+    });
     page = await browser.newPage();
   }, TIMEOUT);
 

--- a/tests/e2e/stencil-static.test.js
+++ b/tests/e2e/stencil-static.test.js
@@ -25,7 +25,10 @@ describe('E2E - stencil project', () => {
 
     await projectInitializer(EXAMPLE_PATH, 'stencil', serverPort);
 
-    browser = await puppeteer.launch({ headless: 'new' });
+    browser = await puppeteer.launch({
+      args: ['--no-sandbox', '--disable-setuid-sandbox'],
+      headless: 'new',
+    });
     page = await browser.newPage();
   }, TIMEOUT);
 

--- a/tests/e2e/svelte-static.test.js
+++ b/tests/e2e/svelte-static.test.js
@@ -25,7 +25,10 @@ describe('E2E - svelte-static project', () => {
 
     await projectInitializer(EXAMPLE_PATH, 'svelte', serverPort);
 
-    browser = await puppeteer.launch({ headless: 'new' });
+    browser = await puppeteer.launch({
+      args: ['--no-sandbox', '--disable-setuid-sandbox'],
+      headless: 'new',
+    });
     page = await browser.newPage();
   }, TIMEOUT);
 

--- a/tests/e2e/vitepress-static.test.js
+++ b/tests/e2e/vitepress-static.test.js
@@ -20,7 +20,10 @@ describe('E2E - vitepress project', () => {
 
     await projectInitializer(EXAMPLE_PATH, 'vitepress', serverPort);
 
-    browser = await puppeteer.launch({ headless: 'new' });
+    browser = await puppeteer.launch({
+      args: ['--no-sandbox', '--disable-setuid-sandbox'],
+      headless: 'new',
+    });
     page = await browser.newPage();
   }, TIMEOUT);
 

--- a/tests/e2e/vue-vite-static.test.js
+++ b/tests/e2e/vue-vite-static.test.js
@@ -25,7 +25,10 @@ describe('E2E - vue-vite-static project', () => {
 
     await projectInitializer(EXAMPLE_PATH, 'vue', serverPort);
 
-    browser = await puppeteer.launch({ headless: 'new' });
+    browser = await puppeteer.launch({
+      args: ['--no-sandbox', '--disable-setuid-sandbox'],
+      headless: 'new',
+    });
     page = await browser.newPage();
   }, TIMEOUT);
 

--- a/tests/e2e/vuepress-static.test.js
+++ b/tests/e2e/vuepress-static.test.js
@@ -20,7 +20,10 @@ describe('E2E - vuepress project', () => {
 
     await projectInitializer(EXAMPLE_PATH, 'vuepress  ', serverPort);
 
-    browser = await puppeteer.launch({ headless: 'new' });
+    browser = await puppeteer.launch({
+      args: ['--no-sandbox', '--disable-setuid-sandbox'],
+      headless: 'new',
+    });
     page = await browser.newPage();
   }, TIMEOUT);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2493,10 +2493,10 @@ axios@^1.6.1:
     form-data "^4.0.0"
     proxy-from-env "^1.1.0"
 
-azion@^1.12.0:
-  version "1.12.0"
-  resolved "https://registry.yarnpkg.com/azion/-/azion-1.12.0.tgz#74d85b3cd406b6e20b61d984dc98aeaee417eb23"
-  integrity sha512-J9upHyyqi40xIhEIM15Wi9/G0RH24OEfTiskSQKK42wyazALtPTKQ0VmFI0l+Uy44cR1vNEo0/eS9NOCI6v12A==
+azion@^1.12.1:
+  version "1.12.1"
+  resolved "https://registry.yarnpkg.com/azion/-/azion-1.12.1.tgz#5d61885ff60e4ec858043f3f00b6b1addc66e001"
+  integrity sha512-Or0v1NZ8ImtSm9g/T8AZS5bn5rBI0pA5nfWeZNE0Wzd16T9GND1ddt0xWOinrfbzEzHAwF//pWu8AJZDx3cEJQ==
   dependencies:
     chalk "^5.3.0"
     progress "^2.0.3"
@@ -8794,16 +8794,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -8862,14 +8853,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -9671,7 +9655,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -9684,15 +9668,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
This pull request includes updates to the end-to-end (E2E) test configurations for various static site projects. The changes primarily involve modifying the Puppeteer launch settings to enhance security by adding sandboxing arguments.

Changes to E2E test configurations:

Updated Puppeteer launch settings to include `--no-sandbox` and `--disable-setuid-sandbox` arguments.

The same changes were applied to other E2E test files for various static site projects, ensuring consistent security improvements across all tests.

### Bonus

fix: update azion library version to 1.12.1