### PR TITLE
feat: new preset qwik

### DIFF
--- a/lib/presets/qwik/azion.config.js
+++ b/lib/presets/qwik/azion.config.js
@@ -1,0 +1,5 @@
+import { Qwik } from 'azion/presets';
+
+const { config } = Qwik;
+
+export default config;

--- a/lib/presets/qwik/config.js
+++ b/lib/presets/qwik/config.js
@@ -1,0 +1,10 @@
+/**
+ * Config to be used in build context.
+ */
+const config = {
+  builder: 'webpack',
+  polyfills: false,
+  custom: {},
+};
+
+export default config;

--- a/lib/presets/qwik/handler.js
+++ b/lib/presets/qwik/handler.js
@@ -1,0 +1,17 @@
+import { mountMPA } from 'azion/utils';
+
+/**
+ * Handles the 'fetch' event.
+ * @param {import('azion/types').FetchEvent} event - The fetch event.
+ * @returns {Promise<Response>} The response for the request.
+ */
+async function handler(event) {
+  try {
+    const myApp = await mountMPA(event.request.url);
+    return myApp;
+  } catch (e) {
+    return new Response('Not Found', { status: 404 });
+  }
+}
+
+export default handler;

--- a/lib/presets/qwik/prebuild.js
+++ b/lib/presets/qwik/prebuild.js
@@ -1,0 +1,52 @@
+import { access, readFile, rm } from 'fs/promises';
+import { exec, getPackageManager, copyDirectory } from '#utils';
+
+const packageManager = await getPackageManager();
+
+/**
+ * Checks if a given file exists
+ * @param {string} filePath Path of the file to be checked
+ * @returns {boolean} Determines whenever the file exists or not
+ */
+async function fileExists(filePath) {
+  try {
+    await access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Runs custom prebuild actions
+ */
+async function prebuild() {
+  const newOutDir = '.edge/storage';
+  const adapterConfig = '/adapters/static/vite.config.ts';
+  let outDir = 'dist';
+
+  // Check if the project has a custom adapter configuration
+  if (await fileExists(adapterConfig)) {
+    // Check if an output path is specified in config file
+    const configFileContent = await readFile(adapterConfig, 'utf-8');
+    const attributeMatch = Array.from(
+      configFileContent.matchAll(/outDir:(.*)\n/g),
+      (match) => match,
+    )[0];
+
+    if (attributeMatch) {
+      // Get the specified value from the config file
+      outDir = attributeMatch[1].trim();
+    }
+  }
+
+  // Build the project
+  await exec(`${packageManager} run build`, 'Qwik', true);
+
+  // Move files to the bundler path
+  copyDirectory(outDir, newOutDir);
+
+  rm(outDir, { recursive: true, force: true });
+}
+
+export default prebuild;

--- a/lib/utils/presets/presets.utils.test.js
+++ b/lib/utils/presets/presets.utils.test.js
@@ -22,6 +22,7 @@ describe('getPresetsList utils', () => {
       'jekyll',
       'next',
       'nuxt',
+      'qwik',
       'react',
       'rustwasm',
       'stencil',

--- a/tests/e2e/qwik-static.test.js
+++ b/tests/e2e/qwik-static.test.js
@@ -1,0 +1,67 @@
+/* eslint-disable jest/expect-expect */
+import supertest from 'supertest';
+import puppeteer from 'puppeteer';
+import projectInitializer from '../utils/project-initializer.js';
+import projectStop from '../utils/project-stop.js';
+import { getContainerPort } from '../utils/docker-env-actions.js';
+
+// timeout in minutes
+const TIMEOUT = 10 * 60 * 1000;
+
+let serverPort;
+let localhostBaseUrl;
+const EXAMPLE_PATH = '/examples/qwik-static';
+
+describe('E2E - qwik-static project', () => {
+  let request;
+  let browser;
+  let page;
+
+  beforeAll(async () => {
+    serverPort = getContainerPort();
+    localhostBaseUrl = `http://0.0.0.0:${serverPort}`;
+
+    request = supertest(localhostBaseUrl);
+
+    await projectInitializer(EXAMPLE_PATH, 'qwik', serverPort);
+
+    browser = await puppeteer.launch({
+      args: ['--no-sandbox', '--disable-setuid-sandbox'],
+      headless: 'new',
+    });
+    page = await browser.newPage();
+  }, TIMEOUT);
+
+  afterAll(async () => {
+    await projectStop(serverPort, EXAMPLE_PATH.replace('/examples/', ''));
+
+    await browser.close();
+  }, TIMEOUT);
+
+  test('Should render home page in "/" route', async () => {
+    await page.goto(`${localhostBaseUrl}/`);
+
+    const pageContent = await page.content();
+    const pageTitle = await page.title();
+
+    expect(pageTitle).toBe('Welcome to Qwik');
+    expect(pageContent).toContain('Have fun building your App with Qwik');
+  });
+
+  test('Should render home page in "/demo/flower" route', async () => {
+    await page.goto(`${localhostBaseUrl}/demo/flower`);
+
+    const pageContent = await page.content();
+    const pageTitle = await page.title();
+
+    expect(pageTitle).toBe('Qwik Flower');
+    expect(pageContent).toContain('Flowers');
+  });
+
+  test('Should return correct asset', async () => {
+    await request
+      .get('/favicon.svg')
+      .expect(200)
+      .expect('Content-Type', 'image/svg+xml');
+  });
+});

--- a/tests/utils/project-initializer.js
+++ b/tests/utils/project-initializer.js
@@ -27,7 +27,7 @@ async function projectInitializer(
 
   if (installPkgs) {
     feedback.info(`[${example}] Installing project dependencies ...`);
-    await execCommandInContainer('yarn', examplePath);
+    await execCommandInContainer('yarn --ignore-engines', examplePath);
   }
 
   feedback.info(`[${example}] Building the project ...`);


### PR DESCRIPTION
Adding a new preset for static apps based in the Qwik framework.

Also adding the flag `--ignore-engines` for the yarn during the tests as some of the Qwik dependencies expects node 20, while we use node 18... It doesn't affect the build though.