### PR TITLE
chore: update azion package version to ~1.14.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "ajv-errors": "^3.0.0",
     "ajv-keywords": "^5.1.0",
     "assert": "^2.0.0",
-    "azion": "^1.14.0",
+    "azion": "~1.14.0",
     "babel-loader": "^9.2.1",
     "bottleneck": "^2.19.5",
     "browserify-zlib": "^0.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2327,10 +2327,10 @@ axios@^1.6.1:
     form-data "^4.0.0"
     proxy-from-env "^1.1.0"
 
-azion@^1.14.0:
-  version "1.14.0"
-  resolved "https://registry.yarnpkg.com/azion/-/azion-1.14.0.tgz#c3ba022c5f933490706bf83d5cb34b89711d9992"
-  integrity sha512-e4SXKr2LAiUTEjBMfp6rbLSoFxrw1ECWaSuvbfVM7ii/sRhxHQjh7K/JUKe6hPZ/8JA7sS/OIUvp+GfpmD52Ug==
+azion@~1.14.0:
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/azion/-/azion-1.14.1.tgz#d854ca7a93d3bb094fcd8b22ba80f8cc1454fe44"
+  integrity sha512-tTI7cCf1g4eZcxUdWwkqIP9lMIu2t6z5VZEw1a0giTV9SGEASib3SvuEZ8ES0235x7+w8g9gz03ATLIzmjIJ8g==
   dependencies:
     chalk "^5.3.0"
     crypto-browserify "^3.12.1"


### PR DESCRIPTION
This pull request includes a minor change to the `package.json` file. The change updates the version specification for the `azion` package from a caret (`^`) to a tilde (`~`), ensuring that only patch updates are allowed.

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L58-R58): Changed the version specifier for `azion` from `^1.14.0` to `~1.14.0` to restrict updates to patch versions only.