### PR TITLE
fix: enhance build command with user-configurable extend option and streamline user config writing

### DIFF
--- a/lib/commands/build/command.ts
+++ b/lib/commands/build/command.ts
@@ -74,6 +74,7 @@ export async function buildCommand(options: BuildCommandOptions) {
     build: {
       ...buildConfig,
       memoryFS: userConfig?.build?.memoryFS,
+      extend: userConfig?.build?.extend,
     },
   };
 

--- a/lib/commands/build/modules/environment/environment.ts
+++ b/lib/commands/build/modules/environment/environment.ts
@@ -56,10 +56,7 @@ export const setEnvironment = async ({
       };
     }
 
-    const hasUserConfig = await envDefault.readUserConfig();
-
-    // Create initial config file if none exists
-    if (!hasUserConfig) await envDefault.writeUserConfig(mergedConfig);
+    await envDefault.writeUserConfig(mergedConfig);
 
     /**
      * Setup environment store with the following rules:

--- a/lib/env/bundler.ts
+++ b/lib/env/bundler.ts
@@ -302,9 +302,7 @@ export async function writeUserConfig(config: AzionConfig): Promise<void> {
     },
   );
 
-  if (!fs.existsSync(configPath)) {
-    await fsPromises.writeFile(configPath, formattedContent);
-  }
+  await fsPromises.writeFile(configPath, formattedContent);
 }
 
 export default {


### PR DESCRIPTION
This pull request includes several changes to the build command and environment setup processes in the project. The most important changes are focused on extending build configurations, simplifying the environment setup, and ensuring user configurations are always written.

### Build Command Enhancements:

* [`lib/commands/build/command.ts`](diffhunk://#diff-444d642d78d59bba66af2fc952fce0cfda79aa637e47c760756973acc864eb51R77): Added support for extending build configurations with a new `extend` property in the `build` object.

### Environment Setup Simplification:

* [`lib/commands/build/modules/environment/environment.ts`](diffhunk://#diff-93f36286cb82f7746ff9eb116786e43075ae9147a80d5654ebb27cdfdd45b877L59-R59): Simplified the environment setup by removing the check for existing user configuration and always writing the merged configuration.

### User Configuration Management:

* [`lib/env/bundler.ts`](diffhunk://#diff-6c79fb35336ff1746728d0c6c7daf0bba6dd7d9b11f335451c3f50087133793cL305-L308): Removed the existence check for the configuration path before writing the user configuration to ensure it is always written.