### PR TITLE
fix: update setEnvironment to return merged configuration

### DIFF
--- a/lib/commands/build/build.ts
+++ b/lib/commands/build/build.ts
@@ -83,10 +83,15 @@ export const build = async ({
     await executePostbuild({ buildConfig: buildConfigSetup, ctx });
 
     // Phase 4: Set Environment
-    await setEnvironment({ config, preset: resolvedPreset, ctx });
+    // TODO: rafactor this to use the same function
+    const mergedConfig = await setEnvironment({
+      config,
+      preset: resolvedPreset,
+      ctx,
+    });
 
     return {
-      config,
+      config: mergedConfig,
       ctx,
     };
   } catch (error: unknown) {

--- a/lib/commands/build/modules/environment/environment.ts
+++ b/lib/commands/build/modules/environment/environment.ts
@@ -26,7 +26,7 @@ export const setEnvironment = async ({
   preset,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   ctx,
-}: EnvironmentParams): Promise<void> => {
+}: EnvironmentParams): Promise<AzionConfig> => {
   try {
     const { config: presetConfig } = preset;
 
@@ -56,7 +56,10 @@ export const setEnvironment = async ({
       };
     }
 
-    await envDefault.writeUserConfig(mergedConfig);
+    const hasUserConfig = await envDefault.readUserConfig();
+
+    // Create initial config file if none exists
+    if (!hasUserConfig) await envDefault.writeUserConfig(mergedConfig);
 
     /**
      * Setup environment store with the following rules:
@@ -75,6 +78,7 @@ export const setEnvironment = async ({
     };
 
     await envDefault.writeStore(storeConfig);
+    return mergedConfig;
   } catch (error) {
     throw new Error(`Failed to set environment: ${(error as Error).message}`);
   }


### PR DESCRIPTION
This pull request includes several changes to the `build` and `setEnvironment` functions in the `lib/commands/build` directory to improve the handling of configuration during the build process. The most important changes include refactoring the `setEnvironment` function to return the merged configuration, updating the `build` function to use the returned configuration, and ensuring that a user configuration file is created if it does not exist.

Improvements to configuration handling:

* [`lib/commands/build/build.ts`](diffhunk://#diff-9fe9462e33844561ee9b50e35e7b0cd210e3ac70b05285e7587e153dfc196195L86-R94): Refactored the `build` function to use the merged configuration returned by `setEnvironment`.

* [`lib/commands/build/modules/environment/environment.ts`](diffhunk://#diff-93f36286cb82f7746ff9eb116786e43075ae9147a80d5654ebb27cdfdd45b877L29-R29): Updated the `setEnvironment` function to return an `AzionConfig` object instead of `void`.

* [`lib/commands/build/modules/environment/environment.ts`](diffhunk://#diff-93f36286cb82f7746ff9eb116786e43075ae9147a80d5654ebb27cdfdd45b877L59-R62): Added a check to create an initial user configuration file if none exists before writing the merged configuration.

* [`lib/commands/build/modules/environment/environment.ts`](diffhunk://#diff-93f36286cb82f7746ff9eb116786e43075ae9147a80d5654ebb27cdfdd45b877R81): Added a return statement to return the merged configuration at the end of the `setEnvironment` function.