### PR TITLE
feat: improvements, command replace and flag only-generate-config to build command

### DIFF
--- a/lib/commands/build/build.ts
+++ b/lib/commands/build/build.ts
@@ -31,6 +31,29 @@ export const build = async (buildParams: BuildParams): Promise<BuildResult> => {
     const resolvedPreset = await resolvePreset(config.build?.preset);
     const buildConfigSetup = await setupBuildConfig(config, resolvedPreset, isProduction);
 
+    // only generate azion.config.js
+    if (options.onlyGenerateConfig) {
+      const mergedConfig = await setEnvironment({
+        config,
+        preset: resolvedPreset,
+        ctx: {
+          production: isProduction ?? BUILD_CONFIG_DEFAULTS.PRODUCTION,
+          skipFrameworkBuild: Boolean(options.skipFrameworkBuild),
+          handler: '',
+        },
+      });
+      feedback.build.success('Build completed successfully with only azion.config');
+      return {
+        config: mergedConfig,
+        ctx: {
+          production: isProduction ?? BUILD_CONFIG_DEFAULTS.PRODUCTION,
+          skipFrameworkBuild: Boolean(options.skipFrameworkBuild),
+          handler: '',
+        },
+        setup: buildConfigSetup,
+      };
+    }
+
     /* Execute build phases */
     // Phase 1: Prebuild
     feedback.prebuild.info('Starting pre-build...');

--- a/lib/commands/build/types.ts
+++ b/lib/commands/build/types.ts
@@ -61,6 +61,7 @@ export interface PresetValueOptions {
 export interface BuildOptions {
   production?: boolean;
   skipFrameworkBuild?: boolean;
+  onlyGenerateConfig?: boolean;
 }
 
 export interface BuildResult {

--- a/lib/commands/config/config.ts
+++ b/lib/commands/config/config.ts
@@ -3,6 +3,56 @@ import { ConfigOptions } from './types';
 import { tryParseJSON } from './utils';
 
 /**
+ * Recursively replaces all occurrences of a placeholder string with a new value
+ * in an object or array structure
+ * @param obj - The object/array to search and replace in
+ * @param placeholder - The placeholder string to replace
+ * @param newValue - The new value to replace the placeholder with
+ * @returns The object with all placeholders replaced
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function replaceInObject(obj: any, placeholder: string, newValue: string): any {
+  if (typeof obj === 'string') {
+    const isMatch = obj.trim() === String(placeholder).trim();
+    return isMatch ? newValue : obj;
+  }
+
+  if (Array.isArray(obj)) {
+    return obj.map((item) => replaceInObject(item, placeholder, newValue));
+  }
+
+  if (obj !== null && typeof obj === 'object') {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result: any = {};
+    for (const [key, value] of Object.entries(obj)) {
+      result[key] = replaceInObject(value, placeholder, newValue);
+    }
+    return result;
+  }
+
+  return obj;
+}
+
+/**
+ * Replaces all occurrences of a placeholder string with a new value
+ * throughout the entire configuration object
+ * @example
+ * // Replace all occurrences of $EDGE_FUNCTION_NAME with "my-func"
+ * replaceConfig({
+ *   placeholder: '$EDGE_FUNCTION_NAME',
+ *   value: 'my-func',
+ *   config: userConfig
+ * });
+ */
+export function replaceConfig(options: {
+  placeholder: string;
+  value: string;
+  config: AzionConfig;
+}): AzionConfig {
+  return replaceInObject(options.config, options.placeholder, options.value) as AzionConfig;
+}
+
+/**
  * Creates a new property in the user's azion.config
  * @example
  * // Create a simple property

--- a/lib/commands/config/types.ts
+++ b/lib/commands/config/types.ts
@@ -1,9 +1,9 @@
 import { AzionConfig } from 'azion/config';
 
 export type ConfigCommandOptions = {
-  command: 'create' | 'read' | 'update' | 'delete';
+  command: 'create' | 'read' | 'update' | 'delete' | 'replace';
   options: {
-    key?: string | string[];
+    key?: string;
     value?:
       | string
       | number

--- a/lib/env/server.ts
+++ b/lib/env/server.ts
@@ -121,10 +121,14 @@ function setCurrentBucketName(edgeFunction?: AzionEdgeFunction): string {
 }
 
 // Helper function to find entry path for a function
-function findEntryPathForFunction(entries: Record<string, string>, functionName: string): string {
+function findEntryPathForFunction(
+  entries: Record<string, string>,
+  functionName: string,
+  targetFunctionPath: string,
+): string {
   const entryPath = Object.keys(entries).find((key) => {
-    const normalizedKey = key.replace(/\.dev$/, '');
-    return normalizedKey.endsWith(functionName);
+    const normalizedKey = key.replace(/\.dev$/, '').replace(/\.edge\//, '');
+    return targetFunctionPath.replace(/\.js$/, '').endsWith(normalizedKey);
   });
 
   if (!entryPath) {
@@ -164,7 +168,7 @@ function defineCurrentFunction(
       throw new Error(`Function "${functionName}" not found in edge functions configuration`);
     }
 
-    const entryPath = findEntryPathForFunction(entries, functionName);
+    const entryPath = findEntryPathForFunction(entries, functionName, targetFunction.path);
     const bucketName = setCurrentBucketName(targetFunction);
 
     return {

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -129,6 +129,17 @@ function startBundler() {
     .option('-d, --dev', 'Build in development mode', false)
     .option('-x, --experimental [boolean]', 'Enable experimental features', false)
     .option('--skip-framework-build', 'Skip framework build step', false)
+    .option('--only-generate-config', 'Build only generate azion.config', false)
+    .addHelpText(
+      'after',
+      `
+Examples:
+  $ ef build -e ./src/index.js -p javascript
+  $ ef build --only-generate-config -e index.js -p javascript
+  $ ef build --preset opennextjs
+  $ ef build --preset opennextjs --skip-framework-build
+    `,
+    )
     .action(async (options) => {
       const { buildCommand, manifestCommand } = await import('#commands');
       const { dev, experimental, ...buildOptions } = options;

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -194,6 +194,32 @@ Examples:
       });
     });
 
+  AzionBundler.command('config <command>')
+    .description('Manage azion.config settings')
+    .option('-k, --key <key...>', 'Property key (e.g., build.preset or edgeApplications[0].name)')
+    .option('-v, --value <value...>', 'Value to be set')
+    .option('-a, --all', 'Read or delete entire configuration (for read/delete commands)')
+    .addHelpText(
+      'after',
+      `
+Examples:
+  $ ef config create -k "build.preset" -v "typescript"
+  $ ef config read -a
+  $ ef config read -k "build.preset"
+  $ ef config update -k "build.preset" -v "vue"
+  $ ef config delete -a
+  $ ef config delete -k "build.preset"
+  $ ef config replace -k '$EDGE_FUNCTION_NAME' -v "my-func"
+    `,
+    )
+    .action(async (command, options) => {
+      const { configCommand } = await import('#commands');
+      await configCommand({
+        command,
+        options,
+      });
+    });
+
   AzionBundler.parse(process.argv);
 }
 

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "@edge-runtime/primitives": "4.0.5",
     "@netlify/framework-info": "^9.9.1",
-    "azion": "~2.0.0-stage.21",
+    "azion": "~2.0.0-stage.22",
     "chokidar": "^3.5.3",
     "commander": "^10.0.1",
     "cosmiconfig": "^9.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3412,10 +3412,10 @@ axios@^1.6.1:
     form-data "^4.0.0"
     proxy-from-env "^1.1.0"
 
-azion@~2.0.0-stage.21:
-  version "2.0.0-stage.21"
-  resolved "https://registry.yarnpkg.com/azion/-/azion-2.0.0-stage.21.tgz#40b864ee7a0471a3cf01b43fd5d48517d5fe6fac"
-  integrity sha512-emGj1hNWQIEWh7+mKxzCT1wjqDKuMbBsG/8eX3LV/RG06ef6rZpHoZ8mMcMnx3n0Wj9erRE8jsWx+R8aDXFegw==
+azion@~2.0.0-stage.22:
+  version "2.0.0-stage.22"
+  resolved "https://registry.yarnpkg.com/azion/-/azion-2.0.0-stage.22.tgz#a919376c4070d0d414cf45e9692bb81ba338e44d"
+  integrity sha512-mOA3jI1p8QU4ylTZB4oBKT/fVhF6Z5IK/aGjA5NFWFYj/B48gcQL4D7eZHQYClj8rCTHBtfXrX8AJ09Biao2Mg==
   dependencies:
     "@babel/plugin-proposal-optional-chaining-assign" "^7.25.9"
     "@babel/preset-env" "^7.26.9"


### PR DESCRIPTION
This pull request introduces two main improvements: a new placeholder replacement feature for configuration management, and enhancements to the build and CLI experience. The placeholder replacement allows users to easily substitute values throughout their `azion.config`, while the build command now supports generating only the configuration file. Several usability and error-handling improvements have also been made.

**Configuration management enhancements:**

* Added a new `replace` command to the `config` CLI, enabling recursive replacement of all occurrences of a placeholder string with a new value in the `azion.config` file. This includes the new `replaceConfig` function and supporting logic. [[1]](diffhunk://#diff-70648c03d531421eb6b0a58d87aa9facbf44d478c0fc016cce8689e498c68060R5-R54) [[2]](diffhunk://#diff-b2e270d4f921fa3f62a3a519db38fe32bfdb6ef9cabb152932cd8dfd6e1165ffL99-R115) [[3]](diffhunk://#diff-b2e270d4f921fa3f62a3a519db38fe32bfdb6ef9cabb152932cd8dfd6e1165ffR277-R305) [[4]](diffhunk://#diff-5e1d161545701356c1dfb3a1c324a1fa8df0bd364ace81cf8702c03a2981b0fbL4-R6)
* Updated CLI help and documentation to include usage examples for the new `replace` command and improved error handling for invalid or missing arguments. [[1]](diffhunk://#diff-b2e270d4f921fa3f62a3a519db38fe32bfdb6ef9cabb152932cd8dfd6e1165ffL99-R115) [[2]](diffhunk://#diff-b2e270d4f921fa3f62a3a519db38fe32bfdb6ef9cabb152932cd8dfd6e1165ffR169) [[3]](diffhunk://#diff-b2e270d4f921fa3f62a3a519db38fe32bfdb6ef9cabb152932cd8dfd6e1165ffL180-R195) [[4]](diffhunk://#diff-b2e270d4f921fa3f62a3a519db38fe32bfdb6ef9cabb152932cd8dfd6e1165ffL252)

**Build process and CLI improvements:**

* Added the `--only-generate-config` option to the build command, allowing users to generate just the `azion.config.js` without performing a full build. [[1]](diffhunk://#diff-9fe9462e33844561ee9b50e35e7b0cd210e3ac70b05285e7587e153dfc196195R34-R56) [[2]](diffhunk://#diff-a2ca326c591df5a3ced87def62e9dfc85eb2ee6eac8a919cbb91d59caf1cfe9bR64) [[3]](diffhunk://#diff-51e2db5c180df3ace5ea7b008165aacf397a9008b1a4545dcf3b4feadc5bccfaR132-R142)
* Enhanced CLI help text for both build and config commands, providing clear usage examples and descriptions for new and existing options. [[1]](diffhunk://#diff-51e2db5c180df3ace5ea7b008165aacf397a9008b1a4545dcf3b4feadc5bccfaR132-R142) [[2]](diffhunk://#diff-51e2db5c180df3ace5ea7b008165aacf397a9008b1a4545dcf3b4feadc5bccfaR208-R233)

**Bug fixes and internal improvements:**

* Improved the logic for resolving entry paths for functions in the environment server code, making it more robust and accurate. [[1]](diffhunk://#diff-d6c5a3212706e41bcc0fc87478a2ad653d61847fa5c0e391d95d792bcb630f6fL124-R131) [[2]](diffhunk://#diff-d6c5a3212706e41bcc0fc87478a2ad653d61847fa5c0e391d95d792bcb630f6fL167-R171)
* Updated the `azion` dependency version in `package.json` to `~2.0.0-stage.22`.