### PR TITLE
fix: add onlyGenerateConfig option and improve storage error message

### DIFF
--- a/lib/commands/build/build.ts
+++ b/lib/commands/build/build.ts
@@ -25,6 +25,10 @@ export const build = async (buildParams: BuildParams): Promise<BuildResult> => {
     const { config, options } = buildParams;
     const isProduction = Boolean(options.production);
 
+    if (options.skipFrameworkBuild) {
+      feedback.build.warn('Skipping framework build');
+    }
+
     validateConfig(config);
     await checkDependencies();
 

--- a/lib/commands/build/command.ts
+++ b/lib/commands/build/command.ts
@@ -61,6 +61,7 @@ export async function buildCommand(options: BuildCommandOptions) {
     options: {
       production: options.production,
       skipFrameworkBuild: options.skipFrameworkBuild,
+      onlyGenerateConfig: options.onlyGenerateConfig,
     },
   });
 }

--- a/lib/commands/build/modules/storage/storage.ts
+++ b/lib/commands/build/modules/storage/storage.ts
@@ -155,7 +155,9 @@ export const setupStorage = async ({ config }: { config: AzionConfig }): Promise
       const sourceDir = path.resolve(process.cwd(), storage.dir);
 
       if (!(await directoryExists(sourceDir))) {
-        throw new Error(`Storage directory not found: ${sourceDir}`);
+        throw new Error(
+          `Storage directory not found: ${sourceDir}. \n- Please check the path provided in the azion.config file on edgeStorage[].dir`,
+        );
       }
 
       const providedPrefix = (storage as BucketSetup).prefix;

--- a/lib/commands/build/types.ts
+++ b/lib/commands/build/types.ts
@@ -37,6 +37,12 @@ export interface BuildCommandOptions {
    * @default false
    */
   skipFrameworkBuild?: boolean;
+
+  /**
+   * Only generate azion.config.js
+   * @default false
+   */
+  onlyGenerateConfig?: boolean;
 }
 
 export interface PackageJson {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "@edge-runtime/primitives": "4.0.5",
     "@netlify/framework-info": "^9.9.1",
-    "azion": "~2.0.0-stage.22",
+    "azion": "~2.0.0-stage.23",
     "chokidar": "^3.5.3",
     "commander": "^10.0.1",
     "cosmiconfig": "^9.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3412,10 +3412,10 @@ axios@^1.6.1:
     form-data "^4.0.0"
     proxy-from-env "^1.1.0"
 
-azion@~2.0.0-stage.22:
-  version "2.0.0-stage.22"
-  resolved "https://registry.yarnpkg.com/azion/-/azion-2.0.0-stage.22.tgz#a919376c4070d0d414cf45e9692bb81ba338e44d"
-  integrity sha512-mOA3jI1p8QU4ylTZB4oBKT/fVhF6Z5IK/aGjA5NFWFYj/B48gcQL4D7eZHQYClj8rCTHBtfXrX8AJ09Biao2Mg==
+azion@~2.0.0-stage.23:
+  version "2.0.0-stage.23"
+  resolved "https://registry.yarnpkg.com/azion/-/azion-2.0.0-stage.23.tgz#ac08b10f1ad431199b73a3c5c8d2adb4f918d3a3"
+  integrity sha512-Jval4xYQa3kLxvMsp3EEuh0GjH9yh9p+MBPjuLgTXtPnRz3Lz0xA03rr8gUtV2E5dNavKPtug4JZZnaQ3xteQg==
   dependencies:
     "@babel/plugin-proposal-optional-chaining-assign" "^7.25.9"
     "@babel/preset-env" "^7.26.9"


### PR DESCRIPTION
This pull request introduces improvements to the build command, including enhanced error messaging, new build options, and a dependency update. The main changes focus on providing better user feedback, expanding build configuration capabilities, and ensuring compatibility with the latest dependencies.

**Build Command Enhancements:**

* Added a warning message when the `skipFrameworkBuild` option is enabled to provide clearer feedback during the build process (`lib/commands/build/build.ts`).
* Introduced the `onlyGenerateConfig` option to the `BuildCommandOptions` interface and passed it through the build command, allowing users to generate only the configuration file without a full build (`lib/commands/build/types.ts`, `lib/commands/build/command.ts`). [[1]](diffhunk://#diff-a2ca326c591df5a3ced87def62e9dfc85eb2ee6eac8a919cbb91d59caf1cfe9bR40-R45) [[2]](diffhunk://#diff-444d642d78d59bba66af2fc952fce0cfda79aa637e47c760756973acc864eb51R64)

**Error Handling Improvements:**

* Improved the error message when the storage directory is not found, including guidance to check the `azion.config` file for the correct path (`lib/commands/build/modules/storage/storage.ts`).

**Dependency Update:**

* Updated the `azion` package dependency from `~2.0.0-stage.22` to `~2.0.0-stage.23` in `package.json` for improved compatibility and features.