### PR TITLE
feat!: update all preset azion.config files for API v4 compatibility

### DIFF
--- a/lib/commands/build/build.ts
+++ b/lib/commands/build/build.ts
@@ -126,7 +126,7 @@ export const build = async (buildParams: BuildParams): Promise<BuildResult> => {
     const storageSetup = await setupStorage({ config: mergedConfig });
 
     // Phase 6: Set Bindings
-    await setupBindings({ config: mergedConfig, storageSetup });
+    await setupBindings({ config: mergedConfig, storageSetup, isProduction });
 
     await copyEnvVars();
 

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -13,13 +13,6 @@ export const DIRECTORIES = {
   OUTPUT_STORAGE_METADATA_PATH: join('.edge', 'storage', 'metadata.json'),
 } as const;
 
-/** Placeholders manifest */
-export const MANIFEST_PLACEHOLDERS = {
-  BUCKET_NAME: '$BUCKET_NAME',
-  BUCKET_NAME_DEFAULT: 'root',
-  LOCAL_BUCKET_DIR: '$LOCAL_BUCKET_DIR',
-} as const;
-
 /** Default build configuration values */
 export const BUILD_CONFIG_DEFAULTS = {
   POLYFILLS: true,

--- a/lib/env/runtime.ts
+++ b/lib/env/runtime.ts
@@ -53,8 +53,15 @@ function runtime(code: string, isFirewallEvent = false) {
   const extend = (context: EdgeContext) => {
     context.RESERVED_FETCH = context.fetch.bind(context);
     context.fetch = async (resource, options) =>
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      fetchContext(context, resource, options, (globalThis as any)?.CURRENT_BUCKET_NAME);
+      fetchContext(
+        context,
+        resource,
+        options,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (globalThis as any)?.AZION_BUCKET_NAME,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (globalThis as any)?.AZION_BUCKET_PREFIX,
+      );
 
     // Set the context for the FetchEvent if it's a Firewall event or a Fetch event
     context.FetchEvent = isFirewallEvent ? FirewallEventContext : FetchEventContext;

--- a/lib/env/server.ts
+++ b/lib/env/server.ts
@@ -15,8 +15,8 @@ import { buildCommand } from '../commands/build';
 import { runServer } from 'edge-runtime';
 import fs from 'fs/promises';
 import { basename } from 'path';
-import { DOCS_MESSAGE, MANIFEST_PLACEHOLDERS } from '#constants';
-import { AzionEdgeFunction } from 'azion/config';
+import { DOCS_MESSAGE } from '#constants';
+import { AzionConfig, AzionEdgeFunction } from 'azion/config';
 let currentServer: Awaited<ReturnType<typeof runServer>>;
 let isChangeHandlerRunning = false;
 
@@ -112,11 +112,8 @@ async function initializeServer(port: number, workerCode: string) {
 }
 
 // Helper function to set current bucket name globally
-function setCurrentBucketName(edgeFunction?: AzionEdgeFunction): string {
-  const bucketName =
-    edgeFunction?.bindings?.storage?.bucket || MANIFEST_PLACEHOLDERS.BUCKET_NAME_DEFAULT;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (globalThis as any).CURRENT_BUCKET_NAME = bucketName;
+function setCurrentBucketName(edgeFunction?: AzionEdgeFunction, config?: AzionConfig): string {
+  const bucketName = edgeFunction?.bindings?.storage?.bucket || config?.edgeStorage?.[0].name || '';
   return bucketName;
 }
 
@@ -169,11 +166,11 @@ function defineCurrentFunction(
     }
 
     const entryPath = findEntryPathForFunction(entries, functionName, targetFunction.path);
-    const bucketName = setCurrentBucketName(targetFunction);
+    // const bucketName = setCurrentBucketName(targetFunction, config);
 
     return {
       name: targetFunction.name,
-      bucket: bucketName,
+      // bucket: bucketName,
       path: normalizePathExtension(entryPath),
     };
   }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "@edge-runtime/primitives": "4.0.5",
     "@netlify/framework-info": "^9.9.1",
-    "azion": "~2.0.0-stage.23",
+    "azion": "~2.0.0-stage.24",
     "chokidar": "^3.5.3",
     "commander": "^10.0.1",
     "cosmiconfig": "^9.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3412,10 +3412,10 @@ axios@^1.6.1:
     form-data "^4.0.0"
     proxy-from-env "^1.1.0"
 
-azion@~2.0.0-stage.23:
-  version "2.0.0-stage.23"
-  resolved "https://registry.yarnpkg.com/azion/-/azion-2.0.0-stage.23.tgz#ac08b10f1ad431199b73a3c5c8d2adb4f918d3a3"
-  integrity sha512-Jval4xYQa3kLxvMsp3EEuh0GjH9yh9p+MBPjuLgTXtPnRz3Lz0xA03rr8gUtV2E5dNavKPtug4JZZnaQ3xteQg==
+azion@~2.0.0-stage.24:
+  version "2.0.0-stage.24"
+  resolved "https://registry.yarnpkg.com/azion/-/azion-2.0.0-stage.24.tgz#8a0121148dda54a091a60982b0898a33ae574699"
+  integrity sha512-xmym6p2gfcRemu07bk9TCtUXm2bl/phOLlHlrVLUgTcj8XKL0ujfLespl24wLmzo83h0eW0WME4YaTqPfMoCZw==
   dependencies:
     "@babel/plugin-proposal-optional-chaining-assign" "^7.25.9"
     "@babel/preset-env" "^7.26.9"


### PR DESCRIPTION
This pull request primarily refactors and simplifies the handling of storage bindings and metadata in the build process, removing legacy placeholder logic and improving how storage name and prefix are injected and used throughout the codebase. It also updates the Azion SDK dependency and streamlines the creation of storage symlinks and metadata files.

**Storage Bindings and Metadata Refactor:**
- Removed usage of `MANIFEST_PLACEHOLDERS` for storage bucket names and replaced it with direct usage of actual storage names throughout the binding and metadata logic, simplifying the code and reducing indirection. [[1]](diffhunk://#diff-61d2c271c50f41e269efa59423ebf921e448cb1324976db85232cdd0989431c8L5-R5) [[2]](diffhunk://#diff-561ab956a0b904914573a9544f92493c5493b6e14d30372365bcdd9c5c7f6e59L16-L22) [[3]](diffhunk://#diff-61d2c271c50f41e269efa59423ebf921e448cb1324976db85232cdd0989431c8L52-L54) [[4]](diffhunk://#diff-61d2c271c50f41e269efa59423ebf921e448cb1324976db85232cdd0989431c8L71-R75) [[5]](diffhunk://#diff-61d2c271c50f41e269efa59423ebf921e448cb1324976db85232cdd0989431c8L92-R95)
- Updated the storage symlink creation to always use the actual storage name and prefix, and ensured the target directory is created recursively.
- Storage metadata is now always saved and logged under the actual storage name, improving traceability and correctness.

**Bindings Injection Improvements:**
- Modified the bindings injection logic to pass an `isProduction` flag, allowing the correct function file (either `.js` or `.dev.js`) to be targeted based on the build environment. [[1]](diffhunk://#diff-9fe9462e33844561ee9b50e35e7b0cd210e3ac70b05285e7587e153dfc196195L129-R129) [[2]](diffhunk://#diff-56973eb0d562b6de714e86b123fc4438791ab99ede1badba2bd417dd33e9e85eR61) [[3]](diffhunk://#diff-56973eb0d562b6de714e86b123fc4438791ab99ede1badba2bd417dd33e9e85eL67-R76) [[4]](diffhunk://#diff-56973eb0d562b6de714e86b123fc4438791ab99ede1badba2bd417dd33e9e85eR137-R141) [[5]](diffhunk://#diff-56973eb0d562b6de714e86b123fc4438791ab99ede1badba2bd417dd33e9e85eL145-R154)
- Temporarily injects storage name and prefix into `globalThis` for runtime access, with a note to migrate this to environment fetch attributes in the future. [[1]](diffhunk://#diff-56973eb0d562b6de714e86b123fc4438791ab99ede1badba2bd417dd33e9e85eL18-R21) [[2]](diffhunk://#diff-61d2c271c50f41e269efa59423ebf921e448cb1324976db85232cdd0989431c8R162-R169)

**Runtime and Server Adjustments:**
- Updated the runtime fetch context to use the new storage name and prefix variables from `globalThis`, replacing the old `CURRENT_BUCKET_NAME`.
- Refactored server logic to remove dependency on `MANIFEST_PLACEHOLDERS` and streamline bucket name resolution. [[1]](diffhunk://#diff-d6c5a3212706e41bcc0fc87478a2ad653d61847fa5c0e391d95d792bcb630f6fL18-R19) [[2]](diffhunk://#diff-d6c5a3212706e41bcc0fc87478a2ad653d61847fa5c0e391d95d792bcb630f6fL115-R116) [[3]](diffhunk://#diff-d6c5a3212706e41bcc0fc87478a2ad653d61847fa5c0e391d95d792bcb630f6fL172-R173)

**Dependency Update:**
- Bumped the `azion` SDK version from `2.0.0-stage.23` to `2.0.0-stage.24`.