### PR TITLE
fix: improve storage cleanup and move bucket globals to server initialization

### DIFF
--- a/lib/commands/build/modules/bindings/bindings.ts
+++ b/lib/commands/build/modules/bindings/bindings.ts
@@ -105,11 +105,6 @@ const injectBindingsIntoFile = async (
         `No prefix provided for binding in function '${func.name}', using storage prefix: ${prefix}`,
       );
     }
-    if (bindingPrefix) {
-      feedback.postbuild.info(
-        `Using provided prefix for binding in function '${func.name}': ${prefix}`,
-      );
-    }
 
     const bindingTemplate = createStorageBindingTemplate({
       bucket: bucketName,

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "@edge-runtime/primitives": "4.0.5",
     "@netlify/framework-info": "^9.9.1",
-    "azion": "~2.0.0-stage.24",
+    "azion": "~2.0.0-stage.25",
     "chokidar": "^3.5.3",
     "commander": "^10.0.1",
     "cosmiconfig": "^9.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3412,10 +3412,10 @@ axios@^1.6.1:
     form-data "^4.0.0"
     proxy-from-env "^1.1.0"
 
-azion@~2.0.0-stage.24:
-  version "2.0.0-stage.24"
-  resolved "https://registry.yarnpkg.com/azion/-/azion-2.0.0-stage.24.tgz#8a0121148dda54a091a60982b0898a33ae574699"
-  integrity sha512-xmym6p2gfcRemu07bk9TCtUXm2bl/phOLlHlrVLUgTcj8XKL0ujfLespl24wLmzo83h0eW0WME4YaTqPfMoCZw==
+azion@~2.0.0-stage.25:
+  version "2.0.0-stage.25"
+  resolved "https://registry.yarnpkg.com/azion/-/azion-2.0.0-stage.25.tgz#a53c6e7ce7f955cedddf3d7dc904562b5701c142"
+  integrity sha512-FqbKGuUM9q9FtmCEuSevQGbca2CWr1zLPQjKIMQfzTCG8JHqh+AizcXhu7c42xPynBJnhrCvqRF5YILImFacEg==
   dependencies:
     "@babel/plugin-proposal-optional-chaining-assign" "^7.25.9"
     "@babel/preset-env" "^7.26.9"


### PR DESCRIPTION
This pull request focuses on improving storage handling and environment setup for edge functions, particularly around bucket and prefix management. The main changes include better cleanup of storage directories and symlinks, refactoring how bucket and prefix values are set and accessed globally, and updating type signatures to support these improvements.

**Storage management improvements:**
- Enhanced the `createStorageSymlink` function to clean up all existing folders (except the current prefix) in the target directory, removing symbolic links, directories, or files as needed, and improved logging for these operations. Also, improved logic for removing existing symlinks or directories before creating a new symlink.
- Removed temporary global variable assignments for bucket name and prefix from `setupStorage`, as this responsibility is now handled elsewhere.

**Environment and type refactoring:**
- Refactored the environment server logic to set the current bucket and prefix globally when managing the server, ensuring these values are available to the runtime. Updated the `defineCurrentFunction` and related helpers to return both `bucket` and `prefix`, and adjusted type signatures accordingly. [[1]](diffhunk://#diff-d6c5a3212706e41bcc0fc87478a2ad653d61847fa5c0e391d95d792bcb630f6fL115-R123) [[2]](diffhunk://#diff-d6c5a3212706e41bcc0fc87478a2ad653d61847fa5c0e391d95d792bcb630f6fL146-R162) [[3]](diffhunk://#diff-d6c5a3212706e41bcc0fc87478a2ad653d61847fa5c0e391d95d792bcb630f6fL169-R197) [[4]](diffhunk://#diff-d6c5a3212706e41bcc0fc87478a2ad653d61847fa5c0e391d95d792bcb630f6fL206-R236)
- Updated imports to include the `AzionBucket` type, supporting the new type signatures.

**Minor improvements:**
- Removed redundant logging of provided binding prefixes in `injectBindingsIntoFile`, streamlining output.
- Updated the `azion` package dependency to version `2.0.0-stage.25`.