### PR TITLE
chore: update azion dependency from ~2.0.0-stage.25 to ~2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "@edge-runtime/primitives": "4.0.5",
     "@netlify/framework-info": "^9.9.1",
-    "azion": "~2.0.0-stage.25",
+    "azion": "~2.0.0",
     "chokidar": "^3.5.3",
     "commander": "^10.0.1",
     "cosmiconfig": "^9.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3412,10 +3412,10 @@ axios@^1.6.1:
     form-data "^4.0.0"
     proxy-from-env "^1.1.0"
 
-azion@~2.0.0-stage.25:
-  version "2.0.0-stage.25"
-  resolved "https://registry.yarnpkg.com/azion/-/azion-2.0.0-stage.25.tgz#a53c6e7ce7f955cedddf3d7dc904562b5701c142"
-  integrity sha512-FqbKGuUM9q9FtmCEuSevQGbca2CWr1zLPQjKIMQfzTCG8JHqh+AizcXhu7c42xPynBJnhrCvqRF5YILImFacEg==
+azion@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/azion/-/azion-2.0.0.tgz#76d9316a3765320cd4ed8ee820c6e421ba8ceaef"
+  integrity sha512-flX1zyrGw8jlBTc9307X3r5DqeSHIKPLa5BOFpdItmKDbirYrkD8sPDGuTue+SuMcRRrPkuZwyRnxivwWYQtEA==
   dependencies:
     "@babel/plugin-proposal-optional-chaining-assign" "^7.25.9"
     "@babel/preset-env" "^7.26.9"


### PR DESCRIPTION
This pull request makes a minor dependency update in the `package.json` file, upgrading the `azion` package from a pre-release version to the stable `2.0.0` release. No other changes are included.

* Upgraded the `azion` dependency from `~2.0.0-stage.25` to the stable `~2.0.0` version in `package.json`.