### PR TITLE
Release 6.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [6.1.0-stage.1](https://github.com/aziontech/bundler/compare/v6.0.0...v6.1.0-stage.1) (2025-08-29)
+
+
+### Features
+
+* rename properties to remove "Edge" prefix ([#508](https://github.com/aziontech/bundler/issues/508)) ([4d3c156](https://github.com/aziontech/bundler/commit/4d3c1561d37443c9e4a553b8e610ab0349e5cec2))
+
 ## [6.0.0](https://github.com/aziontech/bundler/compare/v5.3.0...v6.0.0) (2025-08-21)
 
 

--- a/README.md
+++ b/README.md
@@ -157,13 +157,13 @@ Commands:
   delete              Delete configuration properties
 
 Options:
-  -k, --key <key>     Property key (e.g., build.preset or edgeApplications[0].name)
+  -k, --key <key>     Property key (e.g., build.preset or applications[0].name)
   -v, --value <value> Value to be set (for create/update commands)
   -a, --all           Read or delete entire configuration (for read/delete commands)
 
 Examples:
   $ ef config create -k "build.preset" -v "typescript"
-  $ ef config read -k "edgeApplications[0].name"
+  $ ef config read -k "applications[0].name"
   $ ef config update -k "build.bundler" -v "esbuild"
   $ ef config delete -k "build.polyfills"
   $ ef config read --all

--- a/lib/commands/build/modules/bindings/bindings.ts
+++ b/lib/commands/build/modules/bindings/bindings.ts
@@ -1,7 +1,7 @@
 import { debug } from '#utils';
 import fsPromises from 'fs/promises';
 import path from 'path';
-import { AzionConfig, AzionEdgeFunction } from 'azion/config';
+import { AzionConfig, AzionFunction } from 'azion/config';
 import { BucketSetup } from '../storage/storage';
 import { feedback } from 'azion/utils/node';
 import { DIRECTORIES } from '#constants';
@@ -56,7 +56,7 @@ const findStorageForBinding = (
  * Injects bindings into a single function file
  */
 const injectBindingsIntoFile = async (
-  func: AzionEdgeFunction,
+  func: AzionFunction,
   bucketsSetup: BucketSetup[],
   isProduction: boolean,
 ): Promise<void> => {
@@ -71,18 +71,18 @@ const injectBindingsIntoFile = async (
     return;
   }
 
-  const edgeFunctionsPath = resolveFunctionPath(
+  const functionsPath = resolveFunctionPath(
     func.path.replace(/\.js$/, isProduction ? '.js' : '.dev.js'),
   );
 
-  if (!(await fileExists(edgeFunctionsPath))) {
-    feedback.bindings.warn(`Function file not found: ${edgeFunctionsPath}.`);
+  if (!(await fileExists(functionsPath))) {
+    feedback.bindings.warn(`Function file not found: ${functionsPath}.`);
     feedback.bindings.info(`Binding injection skipped for function ${func.name}`);
     return;
   }
 
   try {
-    const entryContent = await fsPromises.readFile(edgeFunctionsPath, 'utf-8');
+    const entryContent = await fsPromises.readFile(functionsPath, 'utf-8');
 
     // Skip if bindings are already injected
     if (entryContent.includes('//storages:') || entryContent.includes('//---')) {
@@ -115,8 +115,8 @@ const injectBindingsIntoFile = async (
 
     const contentWithBindings = `${bindingTemplate}\n${entryContent}`;
 
-    await fsPromises.writeFile(edgeFunctionsPath, contentWithBindings);
-    debug.info(`Bindings injected into ${edgeFunctionsPath} for function ${func.name}`);
+    await fsPromises.writeFile(functionsPath, contentWithBindings);
+    debug.info(`Bindings injected into ${functionsPath} for function ${func.name}`);
   } catch (error) {
     debug.error(`Failed to process bindings for function ${func.name}:`, error);
     throw error;
@@ -136,7 +136,7 @@ export const setupBindings = async ({
   isProduction: boolean;
 }): Promise<void> => {
   try {
-    const functions = config.edgeFunctions || [];
+    const functions = config.functions || [];
 
     if (functions.length === 0) {
       debug.info('No functions found to inject bindings');

--- a/lib/commands/build/modules/storage/storage.ts
+++ b/lib/commands/build/modules/storage/storage.ts
@@ -166,7 +166,7 @@ const validateStorageConfig = (storage: AzionBucket): boolean => {
  */
 export const setupStorage = async ({ config }: { config: AzionConfig }): Promise<BucketSetup[]> => {
   try {
-    const storages = config.edgeStorage || [];
+    const storages = config.storage || [];
     const processedStorages: BucketSetup[] = [];
 
     if (storages.length === 0) {
@@ -185,7 +185,7 @@ export const setupStorage = async ({ config }: { config: AzionConfig }): Promise
 
       if (!(await directoryExists(sourceDir))) {
         throw new Error(
-          `Storage directory not found: ${sourceDir}. \n- Please check the path provided in the azion.config file on edgeStorage[].dir`,
+          `Storage directory not found: ${sourceDir}. \n- Please check the path provided in the azion.config file on storage[].dir`,
         );
       }
 

--- a/lib/commands/config/command.ts
+++ b/lib/commands/config/command.ts
@@ -28,16 +28,16 @@ import type { AzionConfig } from 'azion/config';
  * ef config create -k "build" -v '{"preset": "react", "bundler": "esbuild", "polyfills": true}'
  *
  * # Create edge application
- * ef config create -k "edgeApplications[0]" -v '{"name": "My App", "edgeCacheEnabled": true}'
+ * ef config create -k "applications[0]" -v '{"name": "My App", "edgeCacheEnabled": true}'
  *
  * # Create edge application with rules
- * ef config create -k "edgeApplications[0].rules.request[0]" -v '{"name": "Static Assets", "behavior": {"deliver": true}}'
+ * ef config create -k "applications[0].rules.request[0]" -v '{"name": "Static Assets", "behavior": {"deliver": true}}'
  *
  * # Create edge function
- * ef config create -k "edgeFunctions[0]" -v '{"name": "auth", "path": "./functions/auth.js"}'
+ * ef config create -k "functions[0]" -v '{"name": "auth", "path": "./functions/auth.js"}'
  *
  * # Create storage configuration
- * ef config create -k "edgeStorage[0]" -v '{"name": "assets", "dir": "./public", "edgeAccess": "read_only"}'
+ * ef config create -k "storage[0]" -v '{"name": "assets", "dir": "./public", "edgeAccess": "read_only"}'
  *
  * === READING CONFIGURATIONS ===
  *
@@ -47,15 +47,15 @@ import type { AzionConfig } from 'azion/config';
  *
  * # Read specific properties
  * ef config read -k "build.preset"
- * ef config read --key "edgeApplications[0].name"
+ * ef config read --key "applications[0].name"
  *
  * # Read nested objects
  * ef config read -k "build"
- * ef config read -k "edgeApplications[0].rules"
+ * ef config read -k "applications[0].rules"
  *
  * # Read array elements
- * ef config read -k "edgeFunctions[0]"
- * ef config read -k "edgeApplications[0].rules.request[1]"
+ * ef config read -k "functions[0]"
+ * ef config read -k "applications[0].rules.request[1]"
  *
  * === UPDATING CONFIGURATIONS ===
  *
@@ -64,13 +64,13 @@ import type { AzionConfig } from 'azion/config';
  * ef config update -k "build.polyfills" -v "false"
  *
  * # Update edge application properties
- * ef config update -k "edgeApplications[0].name" -v "Updated App Name"
- * ef config update -k "edgeApplications[0].edgeCacheEnabled" -v "false"
+ * ef config update -k "applications[0].name" -v "Updated App Name"
+ * ef config update -k "applications[0].edgeCacheEnabled" -v "false"
  *
  * # Update multiple properties at once
  * ef config update \
- *   -k "edgeApplications[0].name" -v "API Produção" \
- *   -k "edgeFunctions[0].name" -v "Function Produção"
+ *   -k "applications[0].name" -v "API Produção" \
+ *   -k "functions[0].name" -v "Function Produção"
  *
  * # Update multiple build settings
  * ef config update \
@@ -78,11 +78,11 @@ import type { AzionConfig } from 'azion/config';
  *   -k "build.polyfills" -v "false" \
  *
  * # Update complex nested structures
- * ef config update -k "edgeApplications[0].rules.request[0].behavior" -v '{"bypassCache": true, "deliver": true}'
+ * ef config update -k "applications[0].rules.request[0].behavior" -v '{"bypassCache": true, "deliver": true}'
  *
  * # Update array elements
- * ef config update -k "edgeFunctions[0].path" -v "./functions/updated-auth.js"
- * ef config update -k "edgeStorage[0].edgeAccess" -v "read_write"
+ * ef config update -k "functions[0].path" -v "./functions/updated-auth.js"
+ * ef config update -k "storage[0].edgeAccess" -v "read_write"
  *
  * === DELETING CONFIGURATIONS ===
  *
@@ -92,14 +92,14 @@ import type { AzionConfig } from 'azion/config';
  *
  * # Delete specific properties
  * ef config delete -k "build.polyfills"
- * ef config delete -k "edgeApplications[0].debug"
+ * ef config delete -k "applications[0].debug"
  *
  * # Delete array elements (removes and shifts)
- * ef config delete -k "edgeFunctions[0]"
- * ef config delete -k "edgeApplications[0].rules.request[1]"
+ * ef config delete -k "functions[0]"
+ * ef config delete -k "applications[0].rules.request[1]"
  *
  * # Delete storage configuration
- * ef config delete -k "edgeStorage[0]"
+ * ef config delete -k "storage[0]"
  *
  * # Delete entire configuration
  * ef config delete --all
@@ -117,10 +117,10 @@ import type { AzionConfig } from 'azion/config';
  * === ADVANCED EXAMPLES ===
  *
  * # Create complete edge application with cache and rules
- * ef config create -k "edgeApplications[0]" -v '{
+ * ef config create -k "applications[0]" -v '{
  *   "name": "Production App",
  *   "edgeCacheEnabled": true,
- *   "edgeFunctionsEnabled": true,
+ *   "functionEnabled": true,
  *   "cache": [
  *     {
  *       "name": "default",

--- a/lib/commands/config/config.test.ts
+++ b/lib/commands/config/config.test.ts
@@ -50,18 +50,18 @@
 //       const edgeApp: AzionEdgeApplication = {
 //         name: 'My Application',
 //         edgeCacheEnabled: true,
-//         edgeFunctionsEnabled: true,
+//         functionEnabled: true,
 //         applicationAcceleratorEnabled: true,
 //         active: true,
 //       };
 
 //       const result = createConfig({
-//         key: 'edgeApplications[0]',
+//         key: 'applications[0]',
 //         value: edgeApp,
 //       });
 
 //       expect(result).toEqual({
-//         edgeApplications: [edgeApp],
+//         applications: [edgeApp],
 //       });
 //     });
 
@@ -76,12 +76,12 @@
 //       };
 
 //       const result = createConfig({
-//         key: 'edgeApplications[0].rules.request[0]',
+//         key: 'applications[0].rules.request[0]',
 //         value: rule,
 //       });
 
 //       expect(result).toEqual({
-//         edgeApplications: [
+//         applications: [
 //           {
 //             rules: {
 //               request: [rule],
@@ -101,7 +101,7 @@
 //         polyfills: true,
 //         worker: false,
 //       },
-//       edgeApplications: [
+//       applications: [
 //         {
 //           name: 'Old App',
 //           edgeCacheEnabled: true,
@@ -127,22 +127,22 @@
 
 //     it('should update an edge application property', () => {
 //       const result = updateConfig({
-//         key: 'edgeApplications[0].name',
+//         key: 'applications[0].name',
 //         value: 'New App',
 //         config: baseConfig,
 //       });
 
-//       expect(result.edgeApplications?.[0].name).toBe('New App');
+//       expect(result.applications?.[0].name).toBe('New App');
 //     });
 
 //     it('should update a request rule', () => {
 //       const result = updateConfig({
-//         key: 'edgeApplications[0].rules.request[1].name',
+//         key: 'applications[0].rules.request[1].name',
 //         value: 'New Rule',
 //         config: baseConfig,
 //       });
 
-//       expect(result.edgeApplications?.[0].rules?.request?.[1].name).toBe('New Rule');
+//       expect(result.applications?.[0].rules?.request?.[1].name).toBe('New Rule');
 //     });
 
 //     it('should update entire array element', () => {
@@ -155,12 +155,12 @@
 //       };
 
 //       const result = updateConfig({
-//         key: 'edgeApplications[0]',
+//         key: 'applications[0]',
 //         value: newApp,
 //         config: baseConfig,
 //       });
 
-//       expect(result.edgeApplications?.[0]).toEqual(newApp);
+//       expect(result.applications?.[0]).toEqual(newApp);
 //     });
 
 //     it('should update nested array element', () => {
@@ -170,12 +170,12 @@
 //       };
 
 //       const result = updateConfig({
-//         key: 'edgeApplications[0].rules.request[0]',
+//         key: 'applications[0].rules.request[0]',
 //         value: newRule,
 //         config: baseConfig,
 //       });
 
-//       expect(result.edgeApplications?.[0].rules?.request?.[0]).toEqual(newRule);
+//       expect(result.applications?.[0].rules?.request?.[0]).toEqual(newRule);
 //     });
 
 //     it('should create property if it does not exist', () => {
@@ -190,13 +190,13 @@
 
 //     it('should extend array when accessing out of bounds index', () => {
 //       const result = updateConfig({
-//         key: 'edgeApplications[1].name',
+//         key: 'applications[1].name',
 //         value: 'New App',
 //         config: baseConfig,
 //       });
 
-//       expect(result.edgeApplications).toHaveLength(2);
-//       expect(result.edgeApplications?.[1].name).toBe('New App');
+//       expect(result.applications).toHaveLength(2);
+//       expect(result.applications?.[1].name).toBe('New App');
 //     });
 
 //     it('should throw error if property is not an array', () => {
@@ -221,13 +221,13 @@
 
 //     it('should extend nested arrays when needed', () => {
 //       const result = updateConfig({
-//         key: 'edgeApplications[0].rules.request[2]',
+//         key: 'applications[0].rules.request[2]',
 //         value: { name: 'New Rule' },
 //         config: baseConfig,
 //       });
 
-//       expect(result.edgeApplications?.[0].rules?.request).toHaveLength(3);
-//       expect(result.edgeApplications?.[0].rules?.request?.[2]).toEqual({ name: 'New Rule' });
+//       expect(result.applications?.[0].rules?.request).toHaveLength(3);
+//       expect(result.applications?.[0].rules?.request?.[2]).toEqual({ name: 'New Rule' });
 //     });
 //   });
 
@@ -240,7 +240,7 @@
 //         polyfills: true,
 //         worker: false,
 //       },
-//       edgeApplications: [
+//       applications: [
 //         {
 //           name: 'My App',
 //           edgeCacheEnabled: true,
@@ -265,7 +265,7 @@
 
 //     it('should read an edge application property', () => {
 //       const result = readConfig({
-//         key: 'edgeApplications[0].name',
+//         key: 'applications[0].name',
 //         config: baseConfig,
 //       });
 
@@ -274,7 +274,7 @@
 
 //     it('should read a request rule', () => {
 //       const result = readConfig({
-//         key: 'edgeApplications[0].rules.request[1].name',
+//         key: 'applications[0].rules.request[1].name',
 //         config: baseConfig,
 //       });
 
@@ -283,7 +283,7 @@
 
 //     it('should read entire array element', () => {
 //       const result = readConfig({
-//         key: 'edgeApplications[0]',
+//         key: 'applications[0]',
 //         config: baseConfig,
 //       });
 
@@ -301,7 +301,7 @@
 
 //     it('should read nested array element', () => {
 //       const result = readConfig({
-//         key: 'edgeApplications[0].rules.request[0]',
+//         key: 'applications[0].rules.request[0]',
 //         config: baseConfig,
 //       });
 
@@ -323,10 +323,10 @@
 //     it('should throw error if array index does not exist', () => {
 //       expect(() => {
 //         readConfig({
-//           key: 'edgeApplications[1].name',
+//           key: 'applications[1].name',
 //           config: baseConfig,
 //         });
-//       }).toThrow("Array index 1 does not exist in 'edgeApplications'");
+//       }).toThrow("Array index 1 does not exist in 'applications'");
 //     });
 
 //     it('should throw error if property is not an array', () => {
@@ -350,7 +350,7 @@
 //     it('should throw error if array index is out of bounds', () => {
 //       expect(() => {
 //         readConfig({
-//           key: 'edgeApplications[0].rules.request[2]',
+//           key: 'applications[0].rules.request[2]',
 //           config: baseConfig,
 //         });
 //       }).toThrow("Array index 2 does not exist in 'request'");
@@ -366,7 +366,7 @@
 //         polyfills: true,
 //         worker: false,
 //       },
-//       edgeApplications: [
+//       applications: [
 //         {
 //           name: 'My App',
 //           edgeCacheEnabled: true,
@@ -391,21 +391,21 @@
 
 //     it('should delete a request rule', () => {
 //       const result = deleteConfig({
-//         key: 'edgeApplications[0].rules.request[1]',
+//         key: 'applications[0].rules.request[1]',
 //         config: baseConfig,
 //       });
 
-//       expect(result.edgeApplications?.[0].rules?.request).toHaveLength(1);
-//       expect(result.edgeApplications?.[0].rules?.request?.[0].name).toBe('Rule 1');
+//       expect(result.applications?.[0].rules?.request).toHaveLength(1);
+//       expect(result.applications?.[0].rules?.request?.[0].name).toBe('Rule 1');
 //     });
 
 //     it('should delete an edge application', () => {
 //       const result = deleteConfig({
-//         key: 'edgeApplications[0]',
+//         key: 'applications[0]',
 //         config: baseConfig,
 //       });
 
-//       expect(result.edgeApplications).toHaveLength(0);
+//       expect(result.applications).toHaveLength(0);
 //     });
 
 //     it('should throw error if property does not exist', () => {
@@ -420,10 +420,10 @@
 //     it('should throw error if array index does not exist', () => {
 //       expect(() => {
 //         deleteConfig({
-//           key: 'edgeApplications[1]',
+//           key: 'applications[1]',
 //           config: baseConfig,
 //         });
-//       }).toThrow("Array index 1 does not exist in 'edgeApplications'");
+//       }).toThrow("Array index 1 does not exist in 'applications'");
 //     });
 //   });
 // });
@@ -437,13 +437,13 @@
 //       polyfills: true,
 //       worker: false,
 //     },
-//     edgeApplications: [
+//     applications: [
 //       {
 //         name: 'Old App',
 //         edgeCacheEnabled: true,
 //       },
 //     ],
-//     edgeFunctions: [
+//     functions: [
 //       {
 //         name: 'Old Function',
 //         path: './functions/old.js',
@@ -462,13 +462,13 @@
 //     const result = (await configCommand({
 //       command: 'update',
 //       options: {
-//         key: ['edgeApplications[0].name', 'edgeFunctions[0].name'],
+//         key: ['applications[0].name', 'functions[0].name'],
 //         value: ['API Produção', 'Function Produção'],
 //       },
 //     })) as AzionConfig;
 
-//     expect(result.edgeApplications?.[0].name).toBe('API Produção');
-//     expect(result.edgeFunctions?.[0].name).toBe('Function Produção');
+//     expect(result.applications?.[0].name).toBe('API Produção');
+//     expect(result.functions?.[0].name).toBe('Function Produção');
 //     expect(mockWriteUserConfig).toHaveBeenCalledWith(result);
 //   });
 
@@ -510,12 +510,12 @@
 //     const result = (await configCommand({
 //       command: 'update',
 //       options: {
-//         key: 'edgeApplications[0].name',
+//         key: 'applications[0].name',
 //         value: 'Single Update',
 //       },
 //     })) as AzionConfig;
 
-//     expect(result.edgeApplications?.[0].name).toBe('Single Update');
+//     expect(result.applications?.[0].name).toBe('Single Update');
 //     expect(mockWriteUserConfig).toHaveBeenCalledWith(result);
 //   });
 
@@ -526,7 +526,7 @@
 //     const readResult = await configCommand({
 //       command: 'read',
 //       options: {
-//         key: ['edgeApplications[0].name', 'edgeFunctions[0].name'],
+//         key: ['applications[0].name', 'functions[0].name'],
 //       },
 //     });
 

--- a/lib/commands/config/config.ts
+++ b/lib/commands/config/config.ts
@@ -63,7 +63,7 @@ export function replaceConfig(options: {
  *
  * // Create an array element
  * createConfig({
- *   key: 'edgeApplications[0].name',
+ *   key: 'applications[0].name',
  *   value: 'My Application'
  * });
  */
@@ -127,7 +127,7 @@ export function createConfig(options: ConfigOptions): AzionConfig {
  *
  * // Updates an existing array element
  * updateConfig({
- *   key: 'edgeApplications[0].name',
+ *   key: 'applications[0].name',
  *   value: 'My Application',
  *   config: userConfig
  * });
@@ -233,7 +233,7 @@ export function updateConfig(options: ConfigOptions): AzionConfig {
  *
  * // Get an array element
  * readConfig({
- *   key: 'edgeApplications[0].name',
+ *   key: 'applications[0].name',
  *   config: userConfig
  * });
  */
@@ -303,7 +303,7 @@ export function readConfig(options: ConfigOptions): unknown {
  *
  * // Delete an array element
  * deleteConfig({
- *   key: 'edgeApplications[0].name',
+ *   key: 'applications[0].name',
  *   config: userConfig
  * });
  */

--- a/lib/commands/presets/presets.test.ts
+++ b/lib/commands/presets/presets.test.ts
@@ -45,7 +45,7 @@ describe('getPresetsList utils', () => {
     expect(result).toBeDefined();
     expect(typeof result).toBe('object');
     expect(result).toHaveProperty('build');
-    expect(result).toHaveProperty('edgeApplications');
+    expect(result).toHaveProperty('applications');
   });
 
   test('Should throw error for invalid preset', () => {

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -207,7 +207,7 @@ Examples:
 
   AzionBundler.command('config <command>')
     .description('Manage azion.config settings')
-    .option('-k, --key <key...>', 'Property key (e.g., build.preset or edgeApplications[0].name)')
+    .option('-k, --key <key...>', 'Property key (e.g., build.preset or applications[0].name)')
     .option('-v, --value <value...>', 'Value to be set')
     .option('-a, --all', 'Read or delete entire configuration (for read/delete commands)')
     .addHelpText(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edge-functions",
-  "version": "6.0.0",
+  "version": "6.1.0-stage.1",
   "description": "Tool to launch and build JavaScript/Frameworks. This tool automates polyfills for Edge Computing and assists in creating Workers, notably for the Azion platform.",
   "main": "dist/main.js",
   "module": "dist/main.ts",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "@edge-runtime/primitives": "4.0.5",
     "@netlify/framework-info": "^9.9.1",
-    "azion": "~2.1.0-stage.1",
+    "azion": "~2.1.0",
     "chokidar": "^3.5.3",
     "commander": "^10.0.1",
     "cosmiconfig": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "@edge-runtime/primitives": "4.0.5",
     "@netlify/framework-info": "^9.9.1",
-    "azion": "~2.0.0",
+    "azion": "~2.1.0-stage.1",
     "chokidar": "^3.5.3",
     "commander": "^10.0.1",
     "cosmiconfig": "^9.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3412,10 +3412,10 @@ axios@^1.6.1:
     form-data "^4.0.0"
     proxy-from-env "^1.1.0"
 
-azion@~2.1.0-stage.1:
-  version "2.1.0-stage.1"
-  resolved "https://registry.yarnpkg.com/azion/-/azion-2.1.0-stage.1.tgz#6746e8bd47ce1c6527d74d10cebd90dcda1accc5"
-  integrity sha512-Hr9Q3KlfalpL/8td8AT2+hZuOwbyV+v2FySfrhbrDA91MxzgcyjcU/bhyy9/Ls1ucerGfdyc+TTtVED+pXBaRg==
+azion@~2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/azion/-/azion-2.1.0.tgz#74010e63746ce376198c8e4e58a7dc50b104bac1"
+  integrity sha512-XpDxuC6om0ft770EatakVSc6pIDRC1SdCm8tQYAYkX1OlrsqxRZurElV1rid3VN7B0XYQYGpV5/1FAibdwigvQ==
   dependencies:
     "@babel/plugin-proposal-optional-chaining-assign" "^7.25.9"
     "@babel/preset-env" "^7.26.9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3412,10 +3412,10 @@ axios@^1.6.1:
     form-data "^4.0.0"
     proxy-from-env "^1.1.0"
 
-azion@~2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/azion/-/azion-2.0.0.tgz#76d9316a3765320cd4ed8ee820c6e421ba8ceaef"
-  integrity sha512-flX1zyrGw8jlBTc9307X3r5DqeSHIKPLa5BOFpdItmKDbirYrkD8sPDGuTue+SuMcRRrPkuZwyRnxivwWYQtEA==
+azion@~2.1.0-stage.1:
+  version "2.1.0-stage.1"
+  resolved "https://registry.yarnpkg.com/azion/-/azion-2.1.0-stage.1.tgz#6746e8bd47ce1c6527d74d10cebd90dcda1accc5"
+  integrity sha512-Hr9Q3KlfalpL/8td8AT2+hZuOwbyV+v2FySfrhbrDA91MxzgcyjcU/bhyy9/Ls1ucerGfdyc+TTtVED+pXBaRg==
   dependencies:
     "@babel/plugin-proposal-optional-chaining-assign" "^7.25.9"
     "@babel/preset-env" "^7.26.9"


### PR DESCRIPTION
⚠️ WARNING: Configuration changes required for azion.config files

This commit renames several properties to remove the "Edge" prefix:

- edgeFunctions → functions
- runtimeFunctionsEnabled → functionsEnabled
- EdgeConnector → Connector
- Edge Storage → Storage
- Edge Firewall → Firewall
- Edge Application → Application

By company decision, this is NOT a breaking change. However, users need to update their azion.config files to use the new property names. The old names are deprecated and will be removed in a future version.

Please update your configuration files accordingly.