### PR TITLE
chore: update azion dependency from 2.1.0-stage.1 to 2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "@edge-runtime/primitives": "4.0.5",
     "@netlify/framework-info": "^9.9.1",
-    "azion": "~2.1.0-stage.1",
+    "azion": "~2.1.0",
     "chokidar": "^3.5.3",
     "commander": "^10.0.1",
     "cosmiconfig": "^9.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3412,10 +3412,10 @@ axios@^1.6.1:
     form-data "^4.0.0"
     proxy-from-env "^1.1.0"
 
-azion@~2.1.0-stage.1:
-  version "2.1.0-stage.1"
-  resolved "https://registry.yarnpkg.com/azion/-/azion-2.1.0-stage.1.tgz#6746e8bd47ce1c6527d74d10cebd90dcda1accc5"
-  integrity sha512-Hr9Q3KlfalpL/8td8AT2+hZuOwbyV+v2FySfrhbrDA91MxzgcyjcU/bhyy9/Ls1ucerGfdyc+TTtVED+pXBaRg==
+azion@~2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/azion/-/azion-2.1.0.tgz#74010e63746ce376198c8e4e58a7dc50b104bac1"
+  integrity sha512-XpDxuC6om0ft770EatakVSc6pIDRC1SdCm8tQYAYkX1OlrsqxRZurElV1rid3VN7B0XYQYGpV5/1FAibdwigvQ==
   dependencies:
     "@babel/plugin-proposal-optional-chaining-assign" "^7.25.9"
     "@babel/preset-env" "^7.26.9"


### PR DESCRIPTION
This pull request updates the `azion` dependency in `package.json` to use the stable `2.1.0` release instead of the previous stage version. This is a minor change that ensures the project uses the latest stable version of the package.