### PR TITLE
fix: allow empty string values in config replace command

### DIFF
--- a/lib/commands/config/command.ts
+++ b/lib/commands/config/command.ts
@@ -241,7 +241,7 @@ export async function configCommand({ command, options }: ConfigCommandOptions) 
         if (!key) {
           throw new Error('Placeholder is required for replace command (use -k or --key)');
         }
-        if (!value) {
+        if (value === undefined) {
           throw new Error('Value is required for replace command');
         }
         // Use direct file replacement instead of object manipulation


### PR DESCRIPTION
This pull request makes a small change to the validation logic in the `configCommand` function. The check for the required `value` argument now explicitly verifies that `value` is not `undefined`, ensuring that empty strings are accepted as valid input.