### PR TITLE
chore: update azion dependency from 2.1.3-stage.3 to ~2.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "@edge-runtime/primitives": "4.0.5",
     "@netlify/framework-info": "^9.9.1",
-    "azion": "2.1.3-stage.3",
+    "azion": "~2.1.3",
     "chokidar": "^3.5.3",
     "commander": "^10.0.1",
     "cosmiconfig": "^9.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3167,10 +3167,10 @@ axios@^1.6.1:
     form-data "^4.0.4"
     proxy-from-env "^1.1.0"
 
-azion@2.1.3-stage.3:
-  version "2.1.3-stage.3"
-  resolved "https://registry.yarnpkg.com/azion/-/azion-2.1.3-stage.3.tgz#f52f98b0201afffab6ffae7a07343e1a6a9c0dae"
-  integrity sha512-1Vb8fmEZ9xhV3f4wmRIC6jMb3nxrvddFR3TFtWZTn1aso6L5pXRFgWT69CQDTgOoC8eN1Ochx4aHzog3HMYDJA==
+azion@~2.1.3:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/azion/-/azion-2.1.3.tgz#0b57a3872964f15ff716aaf148f033c2780d9c1a"
+  integrity sha512-X3OEFZmhQosvJgfefmVlSKkk2kSkf8i/gvFDLflxZ5ujpYnP9QVNrDPg3uU8lzQDLelNJgQ1nwWeBB+XzCOfSw==
   dependencies:
     "@babel/plugin-proposal-optional-chaining-assign" "^7.27.1"
     "@babel/preset-env" "^7.28.3"


### PR DESCRIPTION
This pull request updates the version specification for the `azion` dependency in `package.json` to use a stable release rather than a staged version.

Dependency management:

* Changed the `azion` package version from `2.1.3-stage.3` to `~2.1.3` in `package.json`, ensuring usage of stable releases and enabling compatibility with future patch updates.