### PR TITLE
fix: string escaping

### DIFF
--- a/lib/env/bundler.ts
+++ b/lib/env/bundler.ts
@@ -290,7 +290,7 @@ export async function writeUserConfig(config: AzionConfig): Promise<void> {
     }
 
     if (typeof obj === 'string') {
-      return `'${obj.replace(/'/g, "\\'")}'`;
+      return `'${obj.replaceAll("'", "\\'")}'`;
     }
 
     if (typeof obj === 'number' || typeof obj === 'boolean') {


### PR DESCRIPTION
The [code scan #5](https://github.com/aziontech/bundler/security/code-scanning/5) didn't like the way we were using regex to escape `'`, so I replaced it with a `replaceAll` method. 