### PR TITLE
fix: manifest command default action handling

### DIFF
--- a/lib/commands/manifest/command.ts
+++ b/lib/commands/manifest/command.ts
@@ -31,8 +31,7 @@ export interface ManifestCommandOptions {
  */
 export async function manifestCommand(options: ManifestCommandOptions): Promise<void> {
   try {
-    const action =
-      options.action || (options.config ? ManifestAction.GENERATE : ManifestAction.TRANSFORM);
+    const action = options.action || ManifestAction.GENERATE;
 
     const actionHandlers = {
       [ManifestAction.GENERATE]: async () => {

--- a/lib/commands/manifest/manifest.ts
+++ b/lib/commands/manifest/manifest.ts
@@ -74,7 +74,7 @@ export const transformManifest = async (
   };
 
   const config = await readConfigFromPath(input || DEFAULT_TRANSFORM_INPUT_PATH);
-  await envBundler.writeUserConfig(config);
+  await envBundler.writeUserConfig(config, outputPath);
 
   utilsNode.feedback.manifest.success(`Config file generated successfully at ${outputPath}`);
 };

--- a/lib/env/bundler.ts
+++ b/lib/env/bundler.ts
@@ -216,17 +216,31 @@ function isCommonJS(): boolean {
  * Determines module type (CommonJS/ESM) from package.json
  * @async
  */
-export async function writeUserConfig(config: AzionConfig): Promise<void> {
+export async function writeUserConfig(config: AzionConfig, outputPath?: string): Promise<void> {
   const useCommonJS = isCommonJS();
   const extension = useCommonJS ? '.cjs' : '.mjs';
 
   const isTypeScript = config.build?.preset === 'typescript';
-  const configExtension = isTypeScript ? '.ts' : extension;
-  const configPath = path.join(process.cwd(), `azion.config${configExtension}`);
+  let configExtension = isTypeScript ? '.ts' : extension;
+
+  let configPath: string;
+
+  if (outputPath) {
+    const parsedPath = path.parse(outputPath);
+
+    if (parsedPath.ext) {
+      configPath = path.resolve(outputPath);
+      configExtension = parsedPath.ext;
+    } else {
+      configPath = path.join(outputPath, `azion.config${configExtension}`);
+    }
+  } else {
+    configPath = path.join(process.cwd(), `azion.config${configExtension}`);
+  }
 
   const moduleExportStyle = isTypeScript
     ? 'export default'
-    : useCommonJS
+    : configExtension === '.cjs'
       ? 'module.exports ='
       : 'export default';
   const configComment = `/**

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -184,7 +184,6 @@ Examples:
     .argument(
       '[action]',
       'Action to perform: "transform" (JSON to JS) or "generate" (config to manifest)',
-      'generate',
     )
     .option('-e, --entry <path>', 'Path to the input file or configuration file')
     .option('-o, --output <path>', 'Output file/directory path')
@@ -197,10 +196,13 @@ Examples:
   $ ef manifest -e azion.config.js -o .edge
     `,
     )
-    .action(async (action, options) => {
+    .action(async (action, options, command) => {
       const { manifestCommand } = await import('#commands');
+
+      const actualOptions = options || command;
+
       await manifestCommand({
-        ...options,
+        ...actualOptions,
         action,
       });
     });

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "@edge-runtime/primitives": "4.0.5",
     "@netlify/framework-info": "^9.9.1",
-    "azion": "~2.2.0",
+    "azion": "~2.2.4-stage.2",
     "chokidar": "^3.5.3",
     "commander": "^10.0.1",
     "cosmiconfig": "^9.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3167,10 +3167,10 @@ axios@^1.6.1:
     form-data "^4.0.4"
     proxy-from-env "^1.1.0"
 
-azion@~2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/azion/-/azion-2.2.0.tgz#18aff7602cdb99a39eaa34bab8aeaaf7c92ef86d"
-  integrity sha512-qnxoWOSJMcI0IM3BcXzqIt3JGCXmORCPIqnF6EPVOBbk+dNf1umVPzI6bY0f99PkxBejq0KIjty5nt225gYY/g==
+azion@~2.2.4-stage.2:
+  version "2.2.4-stage.2"
+  resolved "https://registry.yarnpkg.com/azion/-/azion-2.2.4-stage.2.tgz#915a34544b9e1c86972e3cd3278ebab008b242b2"
+  integrity sha512-NmBupbsEkaYodzuhuvN7hHzwMOCCT3YUUMnqjtczKIWcMq1+dJNuMIpN71clVNCrkC83JUHwT1rSmkcXuTX26Q==
   dependencies:
     "@babel/plugin-proposal-optional-chaining-assign" "^7.27.1"
     "@babel/preset-env" "^7.28.3"


### PR DESCRIPTION
This pull request enhances the manifest command functionality by improving how configuration files are generated and written, especially regarding output paths and file extensions. It also updates dependencies and slightly adjusts the CLI interface for better flexibility.

**Manifest command and config generation improvements:**

* The logic for determining the manifest action now always defaults to `GENERATE` unless explicitly specified, making the behavior more predictable and removing ambiguity when `config` is present.
* The `writeUserConfig` function now accepts an optional `outputPath` parameter, allowing users to specify custom output locations and extensions for generated config files. The function intelligently handles file and directory paths, and updates how the config path and extension are determined.
* The `transformManifest` function now passes the `outputPath` to `writeUserConfig`, ensuring the generated config file is written to the correct location as specified by the user.

**CLI and interface updates:**

* The manifest CLI command no longer defaults the `action` argument to `"generate"`, making the command-line interface more explicit and flexible.
* The CLI action handler now merges options more robustly by considering both `options` and `command`, improving reliability in different invocation scenarios.

**Dependency update:**

* The `azion` package dependency is updated from `~2.2.0` to `~2.2.4-stage.2`.