### PR TITLE
fix: move config validation after merging

### DIFF
--- a/lib/commands/build/build.ts
+++ b/lib/commands/build/build.ts
@@ -29,7 +29,6 @@ export const build = async (buildParams: BuildParams): Promise<BuildResult> => {
       feedback.build.warn('Skipping framework build');
     }
 
-    validateConfig(config);
     await checkDependencies();
 
     const resolvedPreset = await resolvePreset(config.build?.preset);
@@ -47,6 +46,10 @@ export const build = async (buildParams: BuildParams): Promise<BuildResult> => {
         },
       });
       feedback.build.success('Build completed successfully with only azion.config');
+
+      // validate config
+      validateConfig(mergedConfig);
+
       return {
         config: mergedConfig,
         ctx: {
@@ -121,6 +124,9 @@ export const build = async (buildParams: BuildParams): Promise<BuildResult> => {
       preset: resolvedPreset,
       ctx,
     });
+
+    // validate config
+    validateConfig(mergedConfig);
 
     // Phase 5: Set Storage
     const storageSetup = await setupStorage({ config: mergedConfig });

--- a/lib/commands/build/modules/environment/utils.ts
+++ b/lib/commands/build/modules/environment/utils.ts
@@ -14,6 +14,10 @@ export const mergeConfigWithUserOverrides = (
     if (objValue && !objValue.build) {
       return srcValue;
     }
+    // se objValue is Array and srcValue is not Array, return srcValue
+    if (Array.isArray(objValue) && !Array.isArray(srcValue)) {
+      return srcValue;
+    }
     return undefined;
   };
 


### PR DESCRIPTION
This pull request introduces improvements to the build process, focusing on configuration validation and enhanced merging logic for build configurations. The main changes ensure that configuration is validated at the appropriate stages and that array merging behaves more intuitively when user overrides are applied.

**Build process improvements:**

* Moved the call to `validateConfig` to occur after merging the configuration (`mergedConfig`) instead of before, ensuring that validation is performed on the final, resolved configuration. [[1]](diffhunk://#diff-9fe9462e33844561ee9b50e35e7b0cd210e3ac70b05285e7587e153dfc196195R49-R52) [[2]](diffhunk://#diff-9fe9462e33844561ee9b50e35e7b0cd210e3ac70b05285e7587e153dfc196195R128-R130)
* Removed the previous call to `validateConfig(config)` before dependency checks, as validation is now done after merging.

**Configuration merging logic:**

* Updated the customizer function in `mergeConfigWithUserOverrides` to return the source value if the original value is an array and the source value is not, improving the handling of array overrides during config merging.