### PR TITLE
fix: update azion dependency to 2.3.0-stage.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "@edge-runtime/primitives": "4.0.5",
     "@netlify/framework-info": "^9.9.1",
-    "azion": "~2.2.4-stage.2",
+    "azion": "~2.3.0-stage.1",
     "chokidar": "^3.5.3",
     "commander": "^10.0.1",
     "cosmiconfig": "^9.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3167,10 +3167,10 @@ axios@^1.6.1:
     form-data "^4.0.4"
     proxy-from-env "^1.1.0"
 
-azion@~2.2.4-stage.2:
-  version "2.2.4-stage.2"
-  resolved "https://registry.yarnpkg.com/azion/-/azion-2.2.4-stage.2.tgz#915a34544b9e1c86972e3cd3278ebab008b242b2"
-  integrity sha512-NmBupbsEkaYodzuhuvN7hHzwMOCCT3YUUMnqjtczKIWcMq1+dJNuMIpN71clVNCrkC83JUHwT1rSmkcXuTX26Q==
+azion@~2.3.0-stage.1:
+  version "2.3.0-stage.1"
+  resolved "https://registry.yarnpkg.com/azion/-/azion-2.3.0-stage.1.tgz#cc2d222726216e49eb136ee38c89eda7648ae9cf"
+  integrity sha512-Ra25nTQPYTPeLy6e7LSFn4nghJy0v+J+whoB5Y7HYU9uTR2feP6HSY5czno7yu8igEg+EegQROQ7cEyHSDa/RQ==
   dependencies:
     "@babel/plugin-proposal-optional-chaining-assign" "^7.27.1"
     "@babel/preset-env" "^7.28.3"


### PR DESCRIPTION
This pull request updates the `azion` package dependency to a newer version in the `package.json` file. No other changes are included.

- Bumped the `azion` dependency from `~2.2.4-stage.2` to `~2.3.0-stage.1` in `package.json` to use the latest features and fixes.