### PR TITLE
fix: update azion dependency to 2.3.0-stage.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "@edge-runtime/primitives": "4.0.5",
     "@netlify/framework-info": "^9.9.1",
-    "azion": "~2.3.0-stage.1",
+    "azion": "~2.3.0-stage.5",
     "chokidar": "^3.5.3",
     "commander": "^10.0.1",
     "cosmiconfig": "^9.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3167,10 +3167,10 @@ axios@^1.6.1:
     form-data "^4.0.4"
     proxy-from-env "^1.1.0"
 
-azion@~2.3.0-stage.1:
-  version "2.3.0-stage.1"
-  resolved "https://registry.yarnpkg.com/azion/-/azion-2.3.0-stage.1.tgz#cc2d222726216e49eb136ee38c89eda7648ae9cf"
-  integrity sha512-Ra25nTQPYTPeLy6e7LSFn4nghJy0v+J+whoB5Y7HYU9uTR2feP6HSY5czno7yu8igEg+EegQROQ7cEyHSDa/RQ==
+azion@~2.3.0-stage.5:
+  version "2.3.0-stage.5"
+  resolved "https://registry.yarnpkg.com/azion/-/azion-2.3.0-stage.5.tgz#3e56ae68df77a9beb1eb1e252781451cfdb1ae67"
+  integrity sha512-sI/kPXD9pFH+VueXcatfPcVuT1se0QbIdpHUIcE/5RS8hHTmSo22SDuzPiG3s7lbuXxoAYZh+sPElC0EIfMdfw==
   dependencies:
     "@babel/plugin-proposal-optional-chaining-assign" "^7.27.1"
     "@babel/preset-env" "^7.28.3"


### PR DESCRIPTION
This pull request updates the `azion` package dependency in the `package.json` file to a newer staged version. This change ensures that the project uses the latest features and fixes available in the `azion` library.

* Dependency update:
  * Upgraded the `azion` package from version `~2.3.0-stage.1` to `~2.3.0-stage.5` in `package.json`.