### PR TITLE
chore: update azion dependency to 2.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "@edge-runtime/primitives": "4.0.5",
     "@netlify/framework-info": "^9.9.1",
-    "azion": "~2.3.0-stage.5",
+    "azion": "~2.3.0",
     "chokidar": "^3.5.3",
     "commander": "^10.0.1",
     "cosmiconfig": "^9.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3167,10 +3167,10 @@ axios@^1.6.1:
     form-data "^4.0.4"
     proxy-from-env "^1.1.0"
 
-azion@~2.3.0-stage.5:
-  version "2.3.0-stage.5"
-  resolved "https://registry.yarnpkg.com/azion/-/azion-2.3.0-stage.5.tgz#3e56ae68df77a9beb1eb1e252781451cfdb1ae67"
-  integrity sha512-sI/kPXD9pFH+VueXcatfPcVuT1se0QbIdpHUIcE/5RS8hHTmSo22SDuzPiG3s7lbuXxoAYZh+sPElC0EIfMdfw==
+azion@~2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/azion/-/azion-2.3.0.tgz#310cddb619dd5ac0a5bef12ded859a2021ebea75"
+  integrity sha512-3/W4X8vygh7epiHHyiHeyNDMfLWhuJHaSJXI+oRP1Bgw5pJzrBGWCgdnvnhH/aOSvtJeBKVLl+/NPf7IdDfCyg==
   dependencies:
     "@babel/plugin-proposal-optional-chaining-assign" "^7.27.1"
     "@babel/preset-env" "^7.28.3"


### PR DESCRIPTION
This pull request updates the `azion` package dependency in `package.json` from a pre-release version to the latest stable release. This change ensures the project is using the most reliable and production-ready version of `azion`.

* Updated the `azion` dependency from `~2.3.0-stage.5` to `~2.3.0` in `package.json`, switching from a pre-release to the stable version.