### PR TITLE
ci: improve release workflows and update bundler dependencies

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -9,7 +9,7 @@
   "commit": false,
   "fixed": [],
   "linked": [],
-  "access": "restricted",
+  "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "ignore": [],

--- a/.github/workflows/prereleases.yml
+++ b/.github/workflows/prereleases.yml
@@ -12,6 +12,8 @@ jobs:
       pull-requests: write
     name: Publish builder package
     runs-on: ubuntu-latest
+    # Skip PRs created by changesets/action (pattern: changeset-release/{branch})
+    if: github.event_name != 'pull_request' || !startsWith(github.event.pull_request.head.ref, 'changeset-release/')
 
     steps:
       - name: Checkout Repo
@@ -21,8 +23,6 @@ jobs:
 
       - name: Install Dependencies
         uses: ./.github/actions/install-dependencies
-        with:
-          node-version: 24
 
       - name: Setup git for changeset
         run: |
@@ -31,7 +31,10 @@ jobs:
 
           # Create local main branch pointing to origin/main
           # Changeset looks for local "main" branch, not origin/main
-          git branch -f main origin/main
+          # Only force update if main is not the current branch (to avoid worktree error)
+          if [ "$(git branch --show-current)" != "main" ]; then
+            git branch -f main origin/main
+          fi
 
       - name: Detect changed packages
         id: changeset

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,22 +5,20 @@ on:
     branches:
       - main
 
-permissions: write-all
+permissions:
+  id-token: write
+  contents: read
 
 jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      issues: write
-      pull-requests: write
-      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          token: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
 
       - name: Install Dependencies
         uses: ./.github/actions/install-dependencies
@@ -35,7 +33,8 @@ jobs:
         uses: changesets/action@v1
         with:
           publish: pnpm exec changeset publish
+          commit: 'chore: version packages'
         env:
           GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
           NODE_ENV: 'production'
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }} // active when publish a new package

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,4 +37,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
           NODE_ENV: 'production'
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }} // active when publish a new package
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/test-e2e-reports.yml
+++ b/.github/workflows/test-e2e-reports.yml
@@ -19,8 +19,6 @@ jobs:
 
       - name: Install Dependencies
         uses: ./.github/actions/install-dependencies
-        with:
-          node-version: 24
 
       - name: Install Docker Compose
         run: |

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -21,8 +21,6 @@ jobs:
 
       - name: Install Dependencies
         uses: ./.github/actions/install-dependencies
-        with:
-          node-version: 24
 
       - name: Install Docker Compose
         run: |

--- a/.github/workflows/test-nodejs-apis.yml
+++ b/.github/workflows/test-nodejs-apis.yml
@@ -20,8 +20,6 @@ jobs:
 
       - name: Install Dependencies
         uses: ./.github/actions/install-dependencies
-        with:
-          node-version: 24
 
       - name: Install Docker Compose
         run: |

--- a/packages/bundler/package.json
+++ b/packages/bundler/package.json
@@ -31,11 +31,11 @@
   "author": "aziontech",
   "license": "MIT",
   "dependencies": {
-    "@aziontech/builder": "https://pkg.pr.new/aziontech/lib/@aziontech/builder@416",
-    "@aziontech/bundler-telemetry": "https://pkg.pr.new/aziontech/lib/@aziontech/bundler-telemetry@416",
-    "@aziontech/config": "https://pkg.pr.new/aziontech/lib/@aziontech/config@416",
-    "@aziontech/utils": "https://pkg.pr.new/aziontech/lib/@aziontech/utils@416",
-    "@aziontech/presets": "https://pkg.pr.new/aziontech/lib/@aziontech/presets@416",
+    "@aziontech/builder": "1.0.1",
+    "@aziontech/bundler-telemetry": "1.0.0",
+    "@aziontech/config": "1.0.0",
+    "@aziontech/utils": "1.0.0",
+    "@aziontech/presets": "1.0.0",
     "@edge-runtime/primitives": "4.0.5",
     "@netlify/framework-info": "^9.9.1",
     "chokidar": "^3.5.3",
@@ -73,7 +73,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/aziontech/bundler.git"
+    "url": "git+https://github.com/aziontech/bundler.git",
+    "directory": "packages/bundler"
   },
   "bugs": {
     "url": "https://github.com/aziontech/bundler/issues"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,20 +69,20 @@ importers:
   packages/bundler:
     dependencies:
       '@aziontech/builder':
-        specifier: https://pkg.pr.new/aziontech/lib/@aziontech/builder@416
-        version: https://pkg.pr.new/aziontech/lib/@aziontech/builder@416(@babel/core@7.29.0)(@fastly/js-compute@3.41.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(typescript@5.9.3))(@jest/transform@29.7.0)(@jest/types@30.3.0)(@swc/core@1.15.24)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@25.5.2)(ts-node@10.9.2(@swc/core@1.15.24)(@types/node@25.5.2)(typescript@5.9.3)))(typescript@5.9.3)
+        specifier: 1.0.1
+        version: 1.0.1(@babel/core@7.29.0)(@fastly/js-compute@3.41.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(typescript@5.9.3))(@jest/transform@29.7.0)(@jest/types@30.3.0)(@swc/core@1.15.24)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@25.5.2)(ts-node@10.9.2(@swc/core@1.15.24)(@types/node@25.5.2)(typescript@5.9.3)))(typescript@5.9.3)
       '@aziontech/bundler-telemetry':
-        specifier: https://pkg.pr.new/aziontech/lib/@aziontech/bundler-telemetry@416
-        version: https://pkg.pr.new/aziontech/lib/@aziontech/bundler-telemetry@416
+        specifier: 1.0.0
+        version: 1.0.0
       '@aziontech/config':
-        specifier: https://pkg.pr.new/aziontech/lib/@aziontech/config@416
-        version: https://pkg.pr.new/aziontech/lib/@aziontech/config@416
+        specifier: 1.0.0
+        version: 1.0.0
       '@aziontech/presets':
-        specifier: https://pkg.pr.new/aziontech/lib/@aziontech/presets@416
-        version: https://pkg.pr.new/aziontech/lib/@aziontech/presets@416(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@30.3.0)(@swc/core@1.15.24)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@25.5.2)(ts-node@10.9.2(@swc/core@1.15.24)(@types/node@25.5.2)(typescript@5.9.3)))(typescript@5.9.3)
+        specifier: 1.0.0
+        version: 1.0.0(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@30.3.0)(@swc/core@1.15.24)(babel-jest@29.7.0(@babel/core@7.29.0))(esbuild@0.25.12)(jest-util@29.7.0)(jest@29.7.0(@types/node@25.5.2)(ts-node@10.9.2(@swc/core@1.15.24)(@types/node@25.5.2)(typescript@5.9.3)))(typescript@5.9.3)
       '@aziontech/utils':
-        specifier: https://pkg.pr.new/aziontech/lib/@aziontech/utils@416
-        version: https://pkg.pr.new/aziontech/lib/@aziontech/utils@416
+        specifier: 1.0.0
+        version: 1.0.0
       '@edge-runtime/primitives':
         specifier: 4.0.5
         version: 4.0.5
@@ -195,45 +195,26 @@ packages:
   '@actions/io@1.1.3':
     resolution: {integrity: sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q==}
 
-  '@aziontech/builder@https://pkg.pr.new/aziontech/lib/@aziontech/builder@416':
-    resolution: {tarball: https://pkg.pr.new/aziontech/lib/@aziontech/builder@416}
-    version: 0.0.0
+  '@aziontech/builder@1.0.1':
+    resolution: {integrity: sha512-uXG8UqwvFyRk6dVW/OrlRdbRdrKmF3F1+8XwnrM6dD5sICewObWnpr7VciNIcmaUnmoAx4h6frgJ/6ut/tmLQQ==}
 
-  '@aziontech/bundler-telemetry@https://pkg.pr.new/aziontech/lib/@aziontech/bundler-telemetry@416':
-    resolution: {tarball: https://pkg.pr.new/aziontech/lib/@aziontech/bundler-telemetry@416}
-    version: 0.0.0
+  '@aziontech/bundler-telemetry@1.0.0':
+    resolution: {integrity: sha512-o4Aa9DSMc2DSTLgU/y4LKMUov4IdFL+gt1bsmfR65DaAogULImOmMWVKAbrL67aVgs1J9jQBCq6gaV2XN0Q6RQ==}
 
-  '@aziontech/config@https://pkg.pr.new/aziontech/lib/@aziontech/config@31819a06704b1d41f633a6d21f711c4928cc6632':
-    resolution: {tarball: https://pkg.pr.new/aziontech/lib/@aziontech/config@31819a06704b1d41f633a6d21f711c4928cc6632}
-    version: 0.0.0
+  '@aziontech/config@1.0.0':
+    resolution: {integrity: sha512-qWXYX7vWTt7PhMA+sNnygttGT6jCIzkg9A+3tn0Z+TyymjZ2JKDmp2lwHzLymgSu2A6lx8Q9ojs+nvywBz9Gjw==}
 
-  '@aziontech/config@https://pkg.pr.new/aziontech/lib/@aziontech/config@416':
-    resolution: {tarball: https://pkg.pr.new/aziontech/lib/@aziontech/config@416}
-    version: 0.0.0
+  '@aziontech/presets@1.0.0':
+    resolution: {integrity: sha512-iFE1e4XlOzWPAwaxItkS1Lk9rK4ezFscRMuw/LuGzkmwJneQPcoEWg7q6GRia0nqT4KxKVMqwLy9CKs6NjW2tA==}
 
-  '@aziontech/presets@https://pkg.pr.new/aziontech/lib/@aziontech/presets@31819a06704b1d41f633a6d21f711c4928cc6632':
-    resolution: {tarball: https://pkg.pr.new/aziontech/lib/@aziontech/presets@31819a06704b1d41f633a6d21f711c4928cc6632}
-    version: 0.0.0
+  '@aziontech/types@1.0.0':
+    resolution: {integrity: sha512-WwLlUu8Ox8mcHaK92QqlXGYRICchY/SyfM+zyAf2QLd4JH/T8ioMXTvc9PWLqVQd5cIWsyYWHaesmoJLybUsSw==}
 
-  '@aziontech/presets@https://pkg.pr.new/aziontech/lib/@aziontech/presets@416':
-    resolution: {tarball: https://pkg.pr.new/aziontech/lib/@aziontech/presets@416}
-    version: 0.0.0
+  '@aziontech/unenv-preset@1.0.0':
+    resolution: {integrity: sha512-MtJjqbpspM3fYjJk3Kc05ge76T+AGxM5Q5AlehgBC2u8zdl0idpTJRUh7UCrCxNDuND+A/ZHBnu/oGenRdSUzg==}
 
-  '@aziontech/types@https://pkg.pr.new/aziontech/lib/@aziontech/types@31819a06704b1d41f633a6d21f711c4928cc6632':
-    resolution: {tarball: https://pkg.pr.new/aziontech/lib/@aziontech/types@31819a06704b1d41f633a6d21f711c4928cc6632}
-    version: 0.0.0
-
-  '@aziontech/unenv-preset@https://pkg.pr.new/aziontech/lib/@aziontech/unenv-preset@31819a06704b1d41f633a6d21f711c4928cc6632':
-    resolution: {tarball: https://pkg.pr.new/aziontech/lib/@aziontech/unenv-preset@31819a06704b1d41f633a6d21f711c4928cc6632}
-    version: 0.0.0
-
-  '@aziontech/utils@https://pkg.pr.new/aziontech/lib/@aziontech/utils@31819a06704b1d41f633a6d21f711c4928cc6632':
-    resolution: {tarball: https://pkg.pr.new/aziontech/lib/@aziontech/utils@31819a06704b1d41f633a6d21f711c4928cc6632}
-    version: 0.0.0
-
-  '@aziontech/utils@https://pkg.pr.new/aziontech/lib/@aziontech/utils@416':
-    resolution: {tarball: https://pkg.pr.new/aziontech/lib/@aziontech/utils@416}
-    version: 0.0.0
+  '@aziontech/utils@1.0.0':
+    resolution: {integrity: sha512-ZMyWm6iIaPszoazCcSprytyy7XSdAfmLyoS1/A2spDlbl/HSdkWj8bGVkdUAK1C3JOTI0UlCj5ClxYdxQx520Q==}
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -1467,6 +1448,7 @@ packages:
 
   '@fastly/js-compute@3.41.0':
     resolution: {integrity: sha512-LPk6E/eeFJjWzHBpG6/1jnq/Fma3+TMa7ATCa5vnCAZouTIFZRRviM2K0hUuLv7pHU91HY30IlIj5Oe9hKgBZA==}
+    deprecated: This version of the Fastly JS SDK has a security vulnerability and has been deprecated. Please upgrade to 3.41.1 or later.
     hasBin: true
     peerDependencies:
       typescript: '>=5.9'
@@ -5567,13 +5549,13 @@ snapshots:
 
   '@actions/io@1.1.3': {}
 
-  '@aziontech/builder@https://pkg.pr.new/aziontech/lib/@aziontech/builder@416(@babel/core@7.29.0)(@fastly/js-compute@3.41.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(typescript@5.9.3))(@jest/transform@29.7.0)(@jest/types@30.3.0)(@swc/core@1.15.24)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@25.5.2)(ts-node@10.9.2(@swc/core@1.15.24)(@types/node@25.5.2)(typescript@5.9.3)))(typescript@5.9.3)':
+  '@aziontech/builder@1.0.1(@babel/core@7.29.0)(@fastly/js-compute@3.41.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(typescript@5.9.3))(@jest/transform@29.7.0)(@jest/types@30.3.0)(@swc/core@1.15.24)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@25.5.2)(ts-node@10.9.2(@swc/core@1.15.24)(@types/node@25.5.2)(typescript@5.9.3)))(typescript@5.9.3)':
     dependencies:
-      '@aziontech/config': https://pkg.pr.new/aziontech/lib/@aziontech/config@31819a06704b1d41f633a6d21f711c4928cc6632
-      '@aziontech/presets': https://pkg.pr.new/aziontech/lib/@aziontech/presets@31819a06704b1d41f633a6d21f711c4928cc6632(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@30.3.0)(@swc/core@1.15.24)(babel-jest@29.7.0(@babel/core@7.29.0))(esbuild@0.25.12)(jest-util@29.7.0)(jest@29.7.0(@types/node@25.5.2)(ts-node@10.9.2(@swc/core@1.15.24)(@types/node@25.5.2)(typescript@5.9.3)))(typescript@5.9.3)
-      '@aziontech/types': https://pkg.pr.new/aziontech/lib/@aziontech/types@31819a06704b1d41f633a6d21f711c4928cc6632
-      '@aziontech/unenv-preset': https://pkg.pr.new/aziontech/lib/@aziontech/unenv-preset@31819a06704b1d41f633a6d21f711c4928cc6632
-      '@aziontech/utils': https://pkg.pr.new/aziontech/lib/@aziontech/utils@31819a06704b1d41f633a6d21f711c4928cc6632
+      '@aziontech/config': 1.0.0
+      '@aziontech/presets': 1.0.0(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@30.3.0)(@swc/core@1.15.24)(babel-jest@29.7.0(@babel/core@7.29.0))(esbuild@0.25.12)(jest-util@29.7.0)(jest@29.7.0(@types/node@25.5.2)(ts-node@10.9.2(@swc/core@1.15.24)(@types/node@25.5.2)(typescript@5.9.3)))(typescript@5.9.3)
+      '@aziontech/types': 1.0.0
+      '@aziontech/unenv-preset': 1.0.0
+      '@aziontech/utils': 1.0.0
       '@babel/plugin-proposal-optional-chaining-assign': 7.27.1(@babel/core@7.29.0)
       '@babel/preset-env': 7.29.2(@babel/core@7.29.0)
       '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
@@ -5615,30 +5597,22 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@aziontech/bundler-telemetry@https://pkg.pr.new/aziontech/lib/@aziontech/bundler-telemetry@416': {}
+  '@aziontech/bundler-telemetry@1.0.0': {}
 
-  '@aziontech/config@https://pkg.pr.new/aziontech/lib/@aziontech/config@31819a06704b1d41f633a6d21f711c4928cc6632':
+  '@aziontech/config@1.0.0':
     dependencies:
-      '@aziontech/types': https://pkg.pr.new/aziontech/lib/@aziontech/types@31819a06704b1d41f633a6d21f711c4928cc6632
+      '@aziontech/types': 1.0.0
       ajv: 8.18.0
       ajv-errors: 3.0.0(ajv@8.18.0)
       ajv-keywords: 5.1.0(ajv@8.18.0)
       mathjs: 13.2.3
 
-  '@aziontech/config@https://pkg.pr.new/aziontech/lib/@aziontech/config@416':
+  '@aziontech/presets@1.0.0(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@30.3.0)(@swc/core@1.15.24)(babel-jest@29.7.0(@babel/core@7.29.0))(esbuild@0.25.12)(jest-util@29.7.0)(jest@29.7.0(@types/node@25.5.2)(ts-node@10.9.2(@swc/core@1.15.24)(@types/node@25.5.2)(typescript@5.9.3)))(typescript@5.9.3)':
     dependencies:
-      '@aziontech/types': https://pkg.pr.new/aziontech/lib/@aziontech/types@31819a06704b1d41f633a6d21f711c4928cc6632
-      ajv: 8.18.0
-      ajv-errors: 3.0.0(ajv@8.18.0)
-      ajv-keywords: 5.1.0(ajv@8.18.0)
-      mathjs: 13.2.3
-
-  '@aziontech/presets@https://pkg.pr.new/aziontech/lib/@aziontech/presets@31819a06704b1d41f633a6d21f711c4928cc6632(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@30.3.0)(@swc/core@1.15.24)(babel-jest@29.7.0(@babel/core@7.29.0))(esbuild@0.25.12)(jest-util@29.7.0)(jest@29.7.0(@types/node@25.5.2)(ts-node@10.9.2(@swc/core@1.15.24)(@types/node@25.5.2)(typescript@5.9.3)))(typescript@5.9.3)':
-    dependencies:
-      '@aziontech/config': https://pkg.pr.new/aziontech/lib/@aziontech/config@31819a06704b1d41f633a6d21f711c4928cc6632
-      '@aziontech/types': https://pkg.pr.new/aziontech/lib/@aziontech/types@31819a06704b1d41f633a6d21f711c4928cc6632
-      '@aziontech/unenv-preset': https://pkg.pr.new/aziontech/lib/@aziontech/unenv-preset@31819a06704b1d41f633a6d21f711c4928cc6632
-      '@aziontech/utils': https://pkg.pr.new/aziontech/lib/@aziontech/utils@31819a06704b1d41f633a6d21f711c4928cc6632
+      '@aziontech/config': 1.0.0
+      '@aziontech/types': 1.0.0
+      '@aziontech/unenv-preset': 1.0.0
+      '@aziontech/utils': 1.0.0
       cookie: 1.1.1
       fast-glob: 3.3.3
       mime-types: 3.0.2
@@ -5659,35 +5633,9 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@aziontech/presets@https://pkg.pr.new/aziontech/lib/@aziontech/presets@416(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@30.3.0)(@swc/core@1.15.24)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@25.5.2)(ts-node@10.9.2(@swc/core@1.15.24)(@types/node@25.5.2)(typescript@5.9.3)))(typescript@5.9.3)':
-    dependencies:
-      '@aziontech/config': https://pkg.pr.new/aziontech/lib/@aziontech/config@31819a06704b1d41f633a6d21f711c4928cc6632
-      '@aziontech/types': https://pkg.pr.new/aziontech/lib/@aziontech/types@31819a06704b1d41f633a6d21f711c4928cc6632
-      '@aziontech/unenv-preset': https://pkg.pr.new/aziontech/lib/@aziontech/unenv-preset@31819a06704b1d41f633a6d21f711c4928cc6632
-      '@aziontech/utils': https://pkg.pr.new/aziontech/lib/@aziontech/utils@31819a06704b1d41f633a6d21f711c4928cc6632
-      cookie: 1.1.1
-      fast-glob: 3.3.3
-      mime-types: 3.0.2
-      pcre-to-regexp: 1.1.0
-      semver: 7.7.4
-      ts-jest: 29.4.9(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@30.3.0)(babel-jest@29.7.0(@babel/core@7.29.0))(esbuild@0.25.12)(jest-util@29.7.0)(jest@29.7.0(@types/node@25.5.2)(ts-node@10.9.2(@swc/core@1.15.24)(@types/node@25.5.2)(typescript@5.9.3)))(typescript@5.9.3)
-      webpack: 5.106.0(@swc/core@1.15.24)(esbuild@0.25.12)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@jest/transform'
-      - '@jest/types'
-      - '@swc/core'
-      - babel-jest
-      - esbuild
-      - jest
-      - jest-util
-      - typescript
-      - uglify-js
-      - webpack-cli
+  '@aziontech/types@1.0.0': {}
 
-  '@aziontech/types@https://pkg.pr.new/aziontech/lib/@aziontech/types@31819a06704b1d41f633a6d21f711c4928cc6632': {}
-
-  '@aziontech/unenv-preset@https://pkg.pr.new/aziontech/lib/@aziontech/unenv-preset@31819a06704b1d41f633a6d21f711c4928cc6632':
+  '@aziontech/unenv-preset@1.0.0':
     dependencies:
       accepts: 1.3.8
       assert-browserify: 2.0.0
@@ -5699,14 +5647,9 @@ snapshots:
       unenv: 2.0.0-rc.24
       url: 0.11.4
 
-  '@aziontech/utils@https://pkg.pr.new/aziontech/lib/@aziontech/utils@31819a06704b1d41f633a6d21f711c4928cc6632':
+  '@aziontech/utils@1.0.0':
     dependencies:
-      '@aziontech/types': https://pkg.pr.new/aziontech/lib/@aziontech/types@31819a06704b1d41f633a6d21f711c4928cc6632
-      signale: 1.4.0
-
-  '@aziontech/utils@https://pkg.pr.new/aziontech/lib/@aziontech/utils@416':
-    dependencies:
-      '@aziontech/types': https://pkg.pr.new/aziontech/lib/@aziontech/types@31819a06704b1d41f633a6d21f711c4928cc6632
+      '@aziontech/types': 1.0.0
       signale: 1.4.0
 
   '@babel/code-frame@7.29.0':


### PR DESCRIPTION
This pull request updates dependency management and CI workflows to improve reliability, security, and maintainability. The main changes include switching from custom tarball URLs to published versions for AzionTech dependencies, refining GitHub Actions workflows for releases and testing, and updating permissions and tokens for improved security.

**Dependency management updates:**

* Switched all `@aziontech/*` dependencies in `packages/bundler/package.json` and `pnpm-lock.yaml` from custom tarball URLs to published version numbers, ensuring more reliable and maintainable package management. [[1]](diffhunk://#diff-08209dd383b294c3c0970b719108b53d46a74d8046e07e3472ab48b87ef02044L34-R38) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL72-R85) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL198-R217) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL5570-R5558) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL5618-R5615) [[6]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL5662-R5638) [[7]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL5702-R5652)
* Updated the `repository` field in `package.json` to include the `directory` property for better monorepo support.
* Added a deprecation warning for the specific version of `@fastly/js-compute` in the lockfile, highlighting a known security vulnerability.

**CI workflow improvements:**

* Updated the `release.yml` workflow to use more restrictive permissions, a custom GitHub token for checkout, and set the correct environment variables for publishing. Also improved the commit message for changeset releases. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L8-R21) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R36-R40)
* Modified the `prereleases.yml` workflow to skip PRs created by the changesets bot, and fixed the logic for updating the local `main` branch to avoid worktree errors. [[1]](diffhunk://#diff-d222a98ebbb50d0533a810ea1520cd202df58f31ee3edf09d0e9f407f3ccd08bR15-R16) [[2]](diffhunk://#diff-d222a98ebbb50d0533a810ea1520cd202df58f31ee3edf09d0e9f407f3ccd08bR34-R37)
* Removed the explicit `node-version` input from dependency installation steps in several workflows, relying on the default version instead. [[1]](diffhunk://#diff-d222a98ebbb50d0533a810ea1520cd202df58f31ee3edf09d0e9f407f3ccd08bL24-L25) [[2]](diffhunk://#diff-9e8d5ad5391be3e30f10156a359c3fb445c5f65df295be33ed4dce3856cf604cL22-L23) [[3]](diffhunk://#diff-976614657a9537dd6476a2977a4a11c0ac912e262006a4ca2d4fe0b4d8cf0becL24-L25) [[4]](diffhunk://#diff-e83f812ff5be82a20666d76e9a1678df91afa72c386452015b67abb342a9ac5eL23-L24)