### PR TITLE
ci(workflows): use custom github token for checkout

### DIFF
--- a/.github/workflows/test-e2e-reports.yml
+++ b/.github/workflows/test-e2e-reports.yml
@@ -16,6 +16,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          token: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
 
       - name: Install Dependencies
         uses: ./.github/actions/install-dependencies

--- a/.github/workflows/test-nodejs-apis.yml
+++ b/.github/workflows/test-nodejs-apis.yml
@@ -17,6 +17,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          token: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
 
       - name: Install Dependencies
         uses: ./.github/actions/install-dependencies


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to improve repository access during CI runs by using a custom GitHub token during the checkout step.

Workflow configuration improvements:

* [`.github/workflows/test-e2e-reports.yml`](diffhunk://#diff-9e8d5ad5391be3e30f10156a359c3fb445c5f65df295be33ed4dce3856cf604cR19): Configured the `actions/checkout` step to use a custom GitHub token (`secrets.CUSTOM_GITHUB_TOKEN`) for authentication.
* [`.github/workflows/test-nodejs-apis.yml`](diffhunk://#diff-e83f812ff5be82a20666d76e9a1678df91afa72c386452015b67abb342a9ac5eR20): Configured the `actions/checkout` step to use a custom GitHub token (`secrets.CUSTOM_GITHUB_TOKEN`) for authentication.