### PR TITLE
ci: notify Slack on E2E/Node.js API test failures instead of committing reports

### DIFF
--- a/.github/actions/notify-slack/action.yml
+++ b/.github/actions/notify-slack/action.yml
@@ -1,0 +1,162 @@
+# =============================================================================
+# notify-slack – Send Slack notifications for workflow status
+# =============================================================================
+name: "Notify Slack"
+description: "Send Slack notification when a scheduled test workflow fails"
+
+inputs:
+  slack-webhook-url:
+    description: "Slack webhook URL"
+    required: true
+  status:
+    description: "Workflow status (success, failure, cancelled)"
+    required: true
+  workflow-name:
+    description: "Name of the workflow"
+    required: true
+  run-id:
+    description: "GitHub Actions run ID"
+    required: true
+  run-url:
+    description: "URL to the workflow run"
+    required: false
+    default: ""
+  branch:
+    description: "Branch name"
+    required: false
+    default: "main"
+  trigger:
+    description: "What triggered the workflow (schedule, manual, etc.)"
+    required: false
+    default: "unknown"
+  test-results-path:
+    description: "Path to the test results JSON file (shape: { passes, testResults: [{ name, passed }] })"
+    required: false
+    default: ""
+  notify-on-success:
+    description: "Send notification on success"
+    required: false
+    default: "false"
+  working-directory:
+    description: "Working directory for reading test results"
+    required: false
+    default: "."
+
+runs:
+  using: "composite"
+  steps:
+    - name: Send Slack notification
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ inputs.slack-webhook-url }}
+        STATUS: ${{ inputs.status }}
+        WORKFLOW_NAME: ${{ inputs.workflow-name }}
+        RUN_ID: ${{ inputs.run-id }}
+        RUN_URL: ${{ inputs.run-url }}
+        BRANCH: ${{ inputs.branch }}
+        TRIGGER: ${{ inputs.trigger }}
+        TEST_RESULTS_PATH: ${{ inputs.test-results-path }}
+        NOTIFY_ON_SUCCESS: ${{ inputs.notify-on-success }}
+        GITHUB_REPO: ${{ github.repository }}
+      run: |
+        # Skip notification on success unless explicitly enabled
+        if [[ "$STATUS" == "success" && "$NOTIFY_ON_SUCCESS" != "true" ]]; then
+          echo "Skipping notification for successful run"
+          exit 0
+        fi
+
+        # Determine status emoji and color
+        case "$STATUS" in
+          success)
+            EMOJI="✅"
+            COLOR="#36a64f"
+            STATUS_TEXT="Succeeded"
+            ;;
+          failure)
+            EMOJI="❌"
+            COLOR="#dc3545"
+            STATUS_TEXT="Failed"
+            ;;
+          cancelled)
+            EMOJI="🚫"
+            COLOR="#ffc107"
+            STATUS_TEXT="Cancelled"
+            ;;
+          *)
+            EMOJI="⚠️"
+            COLOR="#ffc107"
+            STATUS_TEXT="Unknown"
+            ;;
+        esac
+
+        # Build run URL if not provided
+        if [[ -z "$RUN_URL" ]]; then
+          RUN_URL="https://github.com/${GITHUB_REPO}/actions/runs/${RUN_ID}"
+        fi
+
+        # Build message text
+        MESSAGE_TEXT="${EMOJI} *${WORKFLOW_NAME} - ${STATUS_TEXT}*\n"
+        MESSAGE_TEXT="${MESSAGE_TEXT}• *Branch:* ${BRANCH}\n"
+        MESSAGE_TEXT="${MESSAGE_TEXT}• *Trigger:* ${TRIGGER}\n"
+        MESSAGE_TEXT="${MESSAGE_TEXT}• *Run ID:* <${RUN_URL}|${RUN_ID}>\n"
+
+        # Extract test results if available
+        if [[ -n "$TEST_RESULTS_PATH" && -f "$TEST_RESULTS_PATH" ]]; then
+          PASSED=$(jq '[.testResults[] | select(.passed == true)] | length' "$TEST_RESULTS_PATH" 2>/dev/null || echo "0")
+          FAILED=$(jq '[.testResults[] | select(.passed == false)] | length' "$TEST_RESULTS_PATH" 2>/dev/null || echo "0")
+          TOTAL=$(jq '.testResults | length' "$TEST_RESULTS_PATH" 2>/dev/null || echo "0")
+          FAILED_SUITES=$(jq -r '.testResults[] | select(.passed == false) | .name' "$TEST_RESULTS_PATH" 2>/dev/null || true)
+
+          MESSAGE_TEXT="${MESSAGE_TEXT}\n*Test Results:*\n"
+          MESSAGE_TEXT="${MESSAGE_TEXT}• Total suites: ${TOTAL}\n"
+          MESSAGE_TEXT="${MESSAGE_TEXT}• ✅ Passed: ${PASSED}\n"
+          MESSAGE_TEXT="${MESSAGE_TEXT}• ❌ Failed: ${FAILED}\n"
+
+          if [[ -n "$FAILED_SUITES" ]]; then
+            MESSAGE_TEXT="${MESSAGE_TEXT}\n*Failed Suites:*\n"
+            while IFS= read -r suite; do
+              if [[ -n "$suite" ]]; then
+                MESSAGE_TEXT="${MESSAGE_TEXT}• ${suite}\n"
+              fi
+            done <<< "$FAILED_SUITES"
+          fi
+        fi
+
+        # Build Slack payload using blocks format
+        PAYLOAD=$(cat <<EOF
+        {
+          "attachments": [
+            {
+              "color": "${COLOR}",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "${MESSAGE_TEXT}"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+        EOF
+        )
+
+        # Send to Slack
+        echo "Sending Slack notification..."
+        RESPONSE=$(curl -s -w "%{http_code}" -X POST \
+          -H 'Content-Type: application/json' \
+          -d "$PAYLOAD" \
+          "$SLACK_WEBHOOK_URL")
+
+        HTTP_CODE="${RESPONSE: -3}"
+        BODY="${RESPONSE%???}"
+
+        if [[ "$HTTP_CODE" -eq 200 ]]; then
+          echo "✅ Slack notification sent successfully"
+        else
+          echo "⚠️ Failed to send Slack notification (HTTP $HTTP_CODE)"
+          echo "Response: $BODY"
+        fi

--- a/.github/workflows/test-e2e-reports.yml
+++ b/.github/workflows/test-e2e-reports.yml
@@ -7,8 +7,7 @@ on:
 jobs:
   post-merge-tasks:
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
     steps:
@@ -21,6 +20,9 @@ jobs:
       - name: Install Dependencies
         uses: ./.github/actions/install-dependencies
 
+      - name: Install Puppeteer Chrome (host runner)
+        run: pnpm -F @aziontech/bundler exec puppeteer browsers install chrome
+
       - name: Install Docker Compose
         run: |
           curl -L "https://github.com/docker/compose/releases/download/v2.29.7/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
@@ -30,12 +32,15 @@ jobs:
       - name: Run E2E tests
         run: pnpm -F @aziontech/bundler test:e2e
 
-      - name: Process README.md and Commit
-        run: |
-          git config --global user.email "bundler@azion.com"
-          git config --global user.name "Azion Bundler Reports"
-          git add ./packages/bundler/README.md
-          git commit -m "chore: update reports" --no-verify || echo "No changes to commit."
-          git push --force
-        env:
-          GH_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
+      - name: Notify Slack
+        if: always()
+        uses: ./.github/actions/notify-slack
+        with:
+          slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+          status: ${{ job.status }}
+          workflow-name: "E2E Tests Report"
+          run-id: ${{ github.run_id }}
+          branch: ${{ github.ref_name }}
+          trigger: schedule
+          test-results-path: packages/bundler/e2e_results.json
+          notify-on-success: "false"

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -22,6 +22,9 @@ jobs:
       - name: Install Dependencies
         uses: ./.github/actions/install-dependencies
 
+      - name: Install Puppeteer Chrome (host runner)
+        run: pnpm -F @aziontech/bundler exec puppeteer browsers install chrome
+
       - name: Install Docker Compose
         run: |
           curl -L "https://github.com/docker/compose/releases/download/v2.29.7/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose

--- a/.github/workflows/test-nodejs-apis.yml
+++ b/.github/workflows/test-nodejs-apis.yml
@@ -8,8 +8,7 @@ on:
 jobs:
   test-nodejs-apis:
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
     steps:
@@ -22,6 +21,9 @@ jobs:
       - name: Install Dependencies
         uses: ./.github/actions/install-dependencies
 
+      - name: Install Puppeteer Chrome (host runner)
+        run: pnpm -F @aziontech/bundler exec puppeteer browsers install chrome
+
       - name: Install Docker Compose
         run: |
           curl -L "https://github.com/docker/compose/releases/download/v2.29.7/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
@@ -31,12 +33,15 @@ jobs:
       - name: Run E2E tests
         run: pnpm -F @aziontech/bundler test:nodejs-apis
 
-      - name: Process README.md and Commit
-        run: |
-          git config --global user.email "bundler@azion.com"
-          git config --global user.name "Azion Bundler Reports"
-          git add ./docs/nodejs-apis.md
-          git commit -m "chore: update reports node.js apis" --no-verify || echo "No changes to commit."
-          git push --force
-        env:
-          GH_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
+      - name: Notify Slack
+        if: always()
+        uses: ./.github/actions/notify-slack
+        with:
+          slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+          status: ${{ job.status }}
+          workflow-name: "Node.js APIs Tests"
+          run-id: ${{ github.run_id }}
+          branch: ${{ github.ref_name }}
+          trigger: schedule
+          test-results-path: packages/bundler/nodejs_apis_results.json
+          notify-on-success: "false"

--- a/docs/nodejs-apis.md
+++ b/docs/nodejs-apis.md
@@ -28,30 +28,8 @@ export default main;
 
 #### Support report
 
-Tests run daily in the [Bundler Examples](https://github.com/aziontech/bundler-examples/tree/main/examples/runtime-apis/nodejs).
+Tests run daily in the [Bundler Examples](https://github.com/aziontech/bundler-examples/tree/main/examples/runtime-apis/nodejs). Failures are reported to the team on Slack instead of being tracked here.
 
-Table:
-| Test           | Status |
-| -------------- | ------ |
-| Process        | ✅      |
-| Path           | ✅      |
-| Os             | ✅      |
-| String Decoder | ✅      |
-| Timers         | ✅      |
-| Stream         | ✅      |
-| Module         | ✅      |
-| Zlib           | ✅      |
-| Util           | ✅      |
-| Http           | ✅      |
-| Url            | ✅      |
-| Vm             | ✅      |
-| Crypto         | ✅      |
-| Events         | ✅      |
-| Buffer         | ✅      |
-| Fs             | ✅      |
-| Async Hooks    | ✅      |
-
-Last test run date: 07/05/26 04:54:44 AM
 #### Docs support
 
 See support for the Node.js APIs in the [https://www.azion.com/en/documentation/products/azion-edge-runtime/compatibility/node/](https://www.azion.com/en/documentation/products/azion-edge-runtime/compatibility/node/)

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,6 +1,8 @@
-# PR to Release / Deploy Workflow
+# PR to Release Workflow
 
 Below is a mermaid diagram and textual description derived from the workflows in `.github/workflows` of this repo.
+
+We use [Changesets](https://github.com/changesets/changesets) to manage versioning and releases — everything flows through PRs into `main`.
 
 ---
 
@@ -10,45 +12,30 @@ Below is a mermaid diagram and textual description derived from the workflows in
 flowchart TD
     Dev[Developer]
 
-    %% PR creation
-    Dev --> PR[Open or update PR to main or stage]
+    Dev --> Changeset[Add a changeset file to the PR]
+    Changeset --> PR[Open or update PR to main]
 
-    %% PR checks
     PR --> OSV[OSV scanner PR scan]
     PR --> E2E[E2E tests]
+    PR --> Prerelease[Publish prerelease to pkg-pr-new]
 
-    OSV --> PRStatus[PR checks status]
-    E2E --> Verdaccio[E2E uses Verdaccio registry]
-    Verdaccio --> PRStatus
+    OSV --> Merge[Merge PR into main]
+    E2E --> Merge
+    Prerelease --> Merge
 
-    PRStatus --> Merge[Merge PR into main or stage]
-
-    %% Push to branches
     Merge --> PushMain[Push to main]
-    Merge --> PushStage[Push to stage]
+    PushMain --> Release[Release job]
 
-    %% Release jobs
-    PushMain --> ReleaseMain[Release job on main]
-    PushStage --> ReleaseStage[Release job on stage]
+    Release --> VersionPR[Open or update Version Packages PR]
+    Release --> Publish[changeset publish to NPM]
 
-    ReleaseMain --> SemRelMain[semantic release main]
-    ReleaseStage --> SemRelStage[semantic release stage]
+    VersionPR --> MergeVersionPR[Merge Version Packages PR - triggers Release again]
 
-    SemRelMain --> NpmPublishMain[NPM publish main]
-    SemRelStage --> NpmPublishStage[NPM publish stage]
+    PushMain --> SchedE2E[Scheduled E2E reports]
+    PushMain --> SchedNode[Scheduled Node.js API tests]
+    SchedE2E --> Slack[Notify Slack on failure]
+    SchedNode --> Slack
 
-    %% Main to stage sync
-    SemRelMain --> SyncStage[Sync main to stage]
-
-    %% Extra checks on main
-    PushMain --> AzionCli[Azion CLI tests]
-
-    %% Scheduled jobs
-    SemRelMain --> SchedE2E[Scheduled E2E reports]
-    SchedE2E --> SchedVerdaccio[Scheduled E2E uses Verdaccio]
-    SemRelMain --> SchedNode[Scheduled Node.js API tests]
-
-    %% Utility workflow
     Dev --> ManualCleanup[Manual disk cleanup workflow]
 ```
 
@@ -58,111 +45,53 @@ flowchart TD
 
 ### 1. From code change to PR
 
-- **Developer creates branch**
-  - Create a feature branch from `main` or `stage`.
-  - Commit and push changes.
+- **Developer creates a branch** off `main`, commits changes.
+- **Add a changeset**: run `pnpm changeset` and describe the change (patch/minor/major) for each affected package. This creates a markdown file under `.changeset/`.
+- **Open a PR targeting `main`**. The changeset file(s) are part of the PR diff.
 
-- **Open / update PR**
-  - Open a PR targeting `main` or `stage` (or the PR enters a merge queue as a `merge_group` event).
+### 2. PR checks
 
-### 2. PR validation
-
-Triggered by `pull_request` (and `merge_group`) to `main` or `stage`:
+Triggered by `pull_request` to `main`:
 
 - **OSV-Scanner PR Scan (`osv-scanner-pr.yml`)**
-  - Runs `google/osv-scanner-action` reusable workflow.
-  - Scans dependencies for known vulnerabilities.
-  - Reports results as security events / SARIF in the Security tab.
-
-Triggered by `pull_request` to `main` or `stage` (opened, synchronized, reopened):
+  - Runs the `google/osv-scanner-action` reusable workflow.
+  - Scans dependencies for known vulnerabilities and reports as SARIF in the Security tab.
 
 - **E2E Tests (`test-e2e.yml`)**
-  - Skips if the branch is a `dependabot/*` branch.
-  - Steps:
-    - Checkout repo.
-    - `yarn install`.
-    - Install Docker Compose.
-    - Start local infrastructure (including Verdaccio registry) via Docker Compose.
-    - Run `yarn test:e2e` against the Verdaccio-backed environment.
-  - Results appear as a status check on the PR.
+  - Skips `dependabot/*` branches.
+  - `pnpm install`, install Puppeteer/Chrome and Docker Compose, run `pnpm -F @aziontech/bundler test:e2e`.
 
-**Outcome:** The PR should only be merged once both OSV scan and E2E tests (plus any other required checks / reviews) pass.
+- **Publish prereleases (`prereleases.yml`)**
+  - Skips PRs opened by `changesets/action` (branch `changeset-release/*`).
+  - Detects changed packages via `changeset status`, builds them, and publishes a prerelease build of each to [pkg-pr-new](https://github.com/stackblitz-labs/pkg.pr.new) so reviewers can install and test the PR's exact build.
 
-### 3. Merge to main or stage
+**Outcome:** merge only once required checks and reviews pass.
 
-- **Merge PR**
-  - When reviews and checks pass, merge the PR into `main` or `stage`.
-  - This causes a `push` event on the target branch.
+### 3. Merge to main
 
-### 4. Push-triggered release pipeline (deploy)
+Merging the PR triggers a `push` to `main`.
 
-Triggered by `push` to `main` or `stage`:
+### 4. Release pipeline (`release.yml`)
 
-- **Release (`release.yml` – `release` job)**
-  - Runs on both `main` and `stage`.
-  - Steps:
-    - Checkout with full history (and `CUSTOM_GITHUB_TOKEN`).
-    - Setup Node.js (LTS).
-    - `yarn install`.
-    - `yarn build`.
-    - `npx semantic-release` with:
-      - `GITHUB_TOKEN = CUSTOM_GITHUB_TOKEN`.
-      - `NPM_TOKEN / NODE_AUTH_TOKEN` for publishing.
-  - **Effect:**
-    - Creates GitHub releases / tags according to commit messages.
-    - Publishes new package versions to the NPM registry (using the configured tokens), including publishing into Verdaccio when used in the CI environment.
-    - This is effectively the “deploy/release” step for this library.
+Triggered by `push` to `main`. Uses `changesets/action`, which behaves differently depending on whether there are unreleased changesets:
 
-Triggered by `push` to `main` only:
+- **If there are unreleased changeset files:**
+  - Opens (or updates) a PR named "Version Packages" that bumps versions, updates `CHANGELOG.md`s, and removes the consumed changeset files.
+  - This PR is reviewed and merged like any other PR — merging it triggers `release.yml` again.
 
-- **AzionCli tests (`azioncli-test.yml`)**
-  - Runs additional CLI tests using `tests/azion_cli/test.sh`.
-  - Uses `AZION_USERNAME`, `AZION_PASSWORD`, and `WEBHOOK_SLACK_URL` secrets.
-  - Validates integration with Azion CLI after merging into `main`.
+- **If there are no unreleased changesets (i.e. a Version Packages PR was just merged):**
+  - Runs `pnpm exec changeset publish`, which publishes the new package versions to NPM and creates the corresponding GitHub tags/releases.
 
-### 5. Automatic main → stage sync
+So a real release always takes two merges to `main`: the feature PR (with its changeset) and the auto-generated Version Packages PR.
 
-Within `release.yml`:
+### 5. Scheduled post-merge quality jobs
 
-- **`sync-stage` job**
-  - Runs only when:
-    - `github.ref == 'refs/heads/main'`, and
-    - First commit author is **not** `Azion Bundler Reports` (avoids loops from bot commits).
-  - Steps:
-    - Check out the repo.
-    - Configure git user.
-    - `git fetch origin`.
-    - `git pull origin main`.
-    - `git checkout stage`.
-    - `git merge main --allow-unrelated-histories --no-edit -Xtheirs -m "Merge branch 'main' into stage [skip ci]"`.
-    - `git push origin stage`.
-  - **Effect:** Keeps `stage` branch aligned with `main` automatically after a release.
+These run on a schedule from `main` (not on every merge), and post to Slack on failure via `.github/actions/notify-slack`:
 
----
+- **Report Generation (`test-e2e-reports.yml`)** — daily at 02:30 UTC. Runs `test:e2e` and notifies Slack via `SLACK_WEBHOOK_URL` on failure.
+- **Test Node.js APIs (`test-nodejs-apis.yml`)** — daily at 03:30 UTC. Runs `test:nodejs-apis` and notifies Slack on failure.
 
-## Scheduled post-merge quality jobs (not directly on PR)
-
-These run from `main` / `stage`, but are scheduled, not on each merge:
-
-- **Report Generation (`test-e2e-reports.yml`)**
-  - Trigger: `schedule` at `30 2 * * *` (02:30 UTC daily).
-  - Requires `github.ref` to be `refs/heads/main` or `refs/heads/stage`.
-  - Steps:
-    - Checkout, install dependencies.
-    - Install Docker Compose.
-    - Run `yarn test:e2e`.
-    - Update `README.md` with reports and push as `Azion Bundler Reports`.
-
-- **Test Node.js APIs (`test-nodejs-apis.yml`)**
-  - Trigger: `schedule` at `30 3 * * *` (03:30 UTC daily).
-  - Requires `github.ref` to be `refs/heads/main` or `refs/heads/stage`.
-  - Steps:
-    - Checkout, install dependencies.
-    - Install Docker Compose.
-    - Run `yarn test:nodejs-apis`.
-    - Update `docs/nodejs-apis.md` and push as `Azion Bundler Reports`.
-
-These jobs keep documentation and reports up-to-date, but are not part of the synchronous PR → deploy path.
+These keep quality signal fresh but are decoupled from the PR → release path.
 
 ---
 
@@ -170,9 +99,5 @@ These jobs keep documentation and reports up-to-date, but are not part of the sy
 
 - **Manual Disk Cleanup (`manual-cleanup.yml`)**
   - Trigger: `workflow_dispatch` with inputs `clean_docker`, `clean_packages`, `clean_system`, `clean_build`.
-  - Cleans:
-    - Docker resources.
-    - npm/yarn/pnpm caches.
-    - System tool directories, apt cache.
-    - Optional build artifacts (`dist`, `node_modules/.cache`, test result JSONs).
-  - Helps recover disk space in CI; not part of the release flow itself.
+  - Cleans Docker resources, npm/yarn/pnpm caches, system tool directories/apt cache, and optionally build artifacts (`dist`, `node_modules/.cache`, test result JSONs).
+  - Helps recover CI disk space; not part of the release flow itself.

--- a/packages/bundler/README.md
+++ b/packages/bundler/README.md
@@ -355,54 +355,7 @@ export default defineConfig({
 
 ## Supported Features
 
-E2E tests run daily in the [Bundler Examples](https://github.com/aziontech/bundler-examples/tree/main/examples) to ensure that the presets and frameworks continue to work correctly.
-
-Table:
-| Test                                 | Status |
-| ------------------------------------ | ------ |
-| Next 14 2 15 Middleware              | ✅      |
-| Next 13 5 6 I18n                     | ✅      |
-| Next 12 3 4 I18n                     | ✅      |
-| Hexo Static                          | ✅      |
-| Next 13 5 6 Middleware               | ✅      |
-| Next 12 3 4 Middleware               | ✅      |
-| Next Node Pages 12 3 1               | ✅      |
-| Next 13 5 6 Config                   | ✅      |
-| Next 12 3 4 Config                   | ✅      |
-| Html                                 | ✅      |
-| Next Static                          | ✅      |
-| Gatsby Static                        | ✅      |
-| Next Node Pages 12 3 1 Fs            | ✅      |
-| Sveltekit Static                     | ✅      |
-| Vue Vite Static                      | ✅      |
-| Qwik Static                          | ✅      |
-| Opennext Ssr                         | ✅      |
-| Sveltekit Ssr                        | ✅      |
-| Next 12 Static                       | ✅      |
-| Hugo                                 | ✅      |
-| Astro Static                         | ✅      |
-| Simple Js Env Vars                   | ✅      |
-| Eleventy Static                      | ✅      |
-| Simple Js Network List               | ✅      |
-| Angular Static                       | ✅      |
-| React Static                         | ✅      |
-| Svelte Static                        | ✅      |
-| Stencil Static                       | ⚠️     |
-| Vitepress Static                     | ✅      |
-| Preact Static                        | ✅      |
-| Vuepress Static                      | ✅      |
-| Nuxt Static                          | ✅      |
-| Docusaurus Static                    | ✅      |
-| Simple Js Firewall Event             | ✅      |
-| Nuxt Ssr                             | ✅      |
-| Simple Js Network List With Firewall | ✅      |
-| Jekyll Static                        | ✅      |
-| Simple Js Esm Worker                 | ✅      |
-| Simple Js Esm Node                   | ✅      |
-| Simple Js Esm                        | ✅      |
-| Simple Ts Esm                        | ✅      |
-
-Last test run date: 07/05/26 04:19:39 AM
+E2E tests run daily in the [Bundler Examples](https://github.com/aziontech/bundler-examples/tree/main/examples) to ensure that the presets and frameworks continue to work correctly. Failures are reported to the team on Slack instead of being tracked here.
 
 ## Contributing
 

--- a/packages/bundler/package.json
+++ b/packages/bundler/package.json
@@ -61,7 +61,6 @@
     "@types/tmp": "^0.2.6",
     "globals": "^16.0.0",
     "jest": "^30.4.2",
-    "markdown-table": "^3.0.3",
     "mock-fs": "^5.2.0",
     "puppeteer": "^25.3.0",
     "supertest": "^7.2.2",

--- a/packages/bundler/tasks/process-reports-e2e.js
+++ b/packages/bundler/tasks/process-reports-e2e.js
@@ -1,6 +1,5 @@
 import fs from 'fs';
 import { feedback } from '@aziontech/utils/node';
-import { markdownTable } from 'markdown-table';
 
 /**
  *
@@ -65,56 +64,6 @@ function processE2EReports() {
 
     // Write the new object back to the JSON file
     fs.writeFileSync('e2e_results.json', JSON.stringify(newResults, null, 2));
-
-    // Create the Markdown table
-    const table = [
-      ['Test', 'Status'],
-      ...newResults.testResults.map((test) => [test.name, test.passed ? '✅' : '⚠️']),
-    ];
-
-    // Write the Markdown table to the README.md file
-    const readme = fs.readFileSync('README.md', 'utf8');
-    console.log('Reading README.md...');
-
-    // Simplified regular expression
-    const pattern = /(## Supported Features[\s\S]*?)(## Contributing)/;
-    const hasMatch = pattern.test(readme);
-    console.log('Pattern found in README:', hasMatch);
-
-    if (!hasMatch) {
-      console.error('Could not find the correct section in README.');
-      return;
-    }
-
-    const newReadme = readme.replace(
-      pattern,
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      (match, supportedFeatures, contributing) => {
-        const dateOptions = {
-          day: '2-digit',
-          month: '2-digit',
-          year: '2-digit',
-        };
-        const timeOptions = {
-          hour: '2-digit',
-          minute: '2-digit',
-          second: '2-digit',
-        };
-        const newDate = `${new Date().toLocaleDateString(
-          'en-US',
-          dateOptions,
-        )} ${new Date().toLocaleTimeString('en-US', timeOptions)}`;
-
-        return `## Supported Features\n\nE2E tests run daily in the [Bundler Examples](https://github.com/aziontech/bundler-examples/tree/main/examples) to ensure that the presets and frameworks continue to work correctly.\n\nTable:\n${markdownTable(table)}\n\nLast test run date: ${newDate}\n\n## Contributing`;
-      },
-    );
-
-    if (readme === newReadme) {
-      console.error('No changes were made to the content.');
-      return;
-    }
-
-    fs.writeFileSync('README.md', newReadme);
 
     feedback.interactive.success('Report processed successfully.');
   } catch (error) {

--- a/packages/bundler/tasks/process-reports-nodejs-apis.js
+++ b/packages/bundler/tasks/process-reports-nodejs-apis.js
@@ -1,6 +1,5 @@
 import fs from 'fs';
 import { feedback } from '@aziontech/utils/node';
-import { markdownTable } from 'markdown-table';
 
 /**
  *
@@ -44,36 +43,6 @@ function processReports() {
 
     // Write the new object back to the JSON file
     fs.writeFileSync('nodejs_apis_results.json', JSON.stringify(newResults, null, 2));
-
-    // Create the Markdown table
-    const table = [
-      ['Test', 'Status'],
-      ...newResults.testResults.map((test) => [test.name, test.passed ? '✅' : '⚠️']),
-    ];
-
-    // Write the Markdown table to the README.md file
-    const readme = fs.readFileSync('../../docs/nodejs-apis.md', 'utf8');
-    const newReadme = readme.replace(
-      /(Table:\n)(.*?)(\n#### Docs support)/s,
-      (match, p1, p2, p3) => {
-        const dateOptions = {
-          day: '2-digit',
-          month: '2-digit',
-          year: '2-digit',
-        };
-        const timeOptions = {
-          hour: '2-digit',
-          minute: '2-digit',
-          second: '2-digit',
-        };
-        const newDate = `${new Date().toLocaleDateString(
-          'en-US',
-          dateOptions,
-        )} ${new Date().toLocaleTimeString('en-US', timeOptions)}`;
-        return `${p1}${markdownTable(table)}\n\nLast test run date: ${newDate}${p3}`;
-      },
-    );
-    fs.writeFileSync('../../docs/nodejs-apis.md', newReadme);
 
     feedback.interactive.success('Report processed successfully.');
   } catch (error) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,9 +135,6 @@ importers:
       jest:
         specifier: ^30.4.2
         version: 30.4.2(@types/node@25.5.2)(ts-node@10.9.2(@swc/core@1.15.24)(@types/node@25.5.2)(typescript@5.9.3))
-      markdown-table:
-        specifier: ^3.0.3
-        version: 3.0.4
       mock-fs:
         specifier: ^5.2.0
         version: 5.5.0
@@ -3382,9 +3379,6 @@ packages:
   makeerror@1.0.12:
     resolution: {integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==}
 
-  markdown-table@3.0.4:
-    resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
-
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
@@ -4490,7 +4484,7 @@ snapshots:
       '@babel/preset-typescript': 7.29.7(@babel/core@7.29.7)
       '@edge-runtime/primitives': 3.1.1
       accepts: 1.3.8
-      babel-loader: 10.1.1(@babel/core@7.29.7)(webpack@5.108.4(@swc/core@1.15.24)(esbuild@0.25.12))
+      babel-loader: 10.1.1(@babel/core@7.29.7)(webpack@5.108.4(@swc/core@1.15.24))
       browserify-zlib: 0.2.0
       dotenv: 17.4.2
       esbuild: 0.25.12
@@ -4505,7 +4499,7 @@ snapshots:
       stream-http: 3.2.0
       string_decoder: 1.3.0
       timers-browserify: 2.0.12
-      ts-loader: 9.6.2(typescript@5.9.3)(webpack@5.108.4(@swc/core@1.15.24)(esbuild@0.25.12))
+      ts-loader: 9.6.2(typescript@5.9.3)(webpack@5.108.4(@swc/core@1.15.24))
       unenv: 2.0.0-rc.24
       url: 0.11.4
       util: 0.12.5
@@ -6830,7 +6824,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-loader@10.1.1(@babel/core@7.29.7)(webpack@5.108.4(@swc/core@1.15.24)(esbuild@0.25.12)):
+  babel-loader@10.1.1(@babel/core@7.29.7)(webpack@5.108.4(@swc/core@1.15.24)):
     dependencies:
       '@babel/core': 7.29.7
       find-up: 5.0.0
@@ -8209,8 +8203,6 @@ snapshots:
     dependencies:
       tmpl: 1.0.5
 
-  markdown-table@3.0.4: {}
-
   math-intrinsics@1.1.0: {}
 
   mathjs@15.2.0:
@@ -8947,7 +8939,7 @@ snapshots:
       babel-jest: 30.4.1(@babel/core@7.29.7)
       jest-util: 30.4.1
 
-  ts-loader@9.6.2(typescript@5.9.3)(webpack@5.108.4(@swc/core@1.15.24)(esbuild@0.25.12)):
+  ts-loader@9.6.2(typescript@5.9.3)(webpack@5.108.4(@swc/core@1.15.24)):
     dependencies:
       chalk: 4.1.2
       picomatch: 4.0.4


### PR DESCRIPTION
- the scheduled workflows were force-pushing generated test reports into docs/nodejs-apis.md and packages/bundler/README.md daily. Replace that with a Slack notification on failure, so results are surfaced without noisy commits or stale tables tracked in the repo.