### PR TITLE
test: ensure report processing always runs and configure HMAC_SECRET for crypto test

### DIFF
--- a/packages/bundler/package.json
+++ b/packages/bundler/package.json
@@ -24,8 +24,8 @@
     "e2e:start": "pnpm submodule:update && tests/scripts/start-e2e-env.sh",
     "e2e:stop": "tests/scripts/stop-e2e-env.sh",
     "e2e:destroy": "tests/scripts/destroy-e2e-env.sh",
-    "test:e2e": "pnpm e2e:start && NODE_OPTIONS='--experimental-vm-modules' jest --detectOpenHandles --forceExit --runInBand --config=./jest-e2e.config.js tests/e2e/ --json --outputFile e2e_results.json && pnpm e2e:stop; pnpm task:reports",
-    "test:nodejs-apis": "pnpm e2e:start && NODE_OPTIONS='--experimental-vm-modules' jest --forceExit --runInBand --config=./jest-e2e.config.js tests/nodejs-apis/ --json --outputFile nodejs_apis_results.json && pnpm e2e:stop && pnpm task:reports-nodejs-apis",
+    "test:e2e": "pnpm e2e:start && NODE_OPTIONS='--experimental-vm-modules' jest --detectOpenHandles --forceExit --runInBand --config=./jest-e2e.config.js tests/e2e/ --json --outputFile e2e_results.json; TEST_EXIT_CODE=$?; pnpm e2e:stop; pnpm task:reports; exit $TEST_EXIT_CODE",
+    "test:nodejs-apis": "pnpm e2e:start && NODE_OPTIONS='--experimental-vm-modules' jest --forceExit --runInBand --config=./jest-e2e.config.js tests/nodejs-apis/ --json --outputFile nodejs_apis_results.json; TEST_EXIT_CODE=$?; pnpm e2e:stop; pnpm task:reports-nodejs-apis; exit $TEST_EXIT_CODE",
     "submodule:update": "git submodule update --init --recursive && git submodule foreach git pull origin main"
   },
   "author": "aziontech",

--- a/packages/bundler/tests/nodejs-apis/crypto.test.js
+++ b/packages/bundler/tests/nodejs-apis/crypto.test.js
@@ -2,7 +2,7 @@ import supertest from 'supertest';
 import { expect } from '@jest/globals';
 import projectInitializer from '../utils/project-initializer.js';
 import projectStop from '../utils/project-stop.js';
-import { getContainerPort } from '../utils/docker-env-actions.js';
+import { execCommandInContainer, getContainerPort } from '../utils/docker-env-actions.js';
 
 // timeout in minutes
 const TIMEOUT = 1 * 60 * 3000;
@@ -19,6 +19,8 @@ describe('Node.js APIs - crypto', () => {
     localhostBaseUrl = `http://0.0.0.0:${serverPort}`;
 
     request = supertest(localhostBaseUrl);
+
+    await execCommandInContainer(`sh -c 'echo "HMAC_SECRET=test-secret-key" > .env'`, EXAMPLE_PATH);
 
     await projectInitializer(
       EXAMPLE_PATH,


### PR DESCRIPTION
Report generation was skipped whenever jest exited non-zero (`&&` chain), leaving the raw Jest JSON in a shape the Slack notifier can't parse. The crypto e2e example now requires HMAC_SECRET, which the test never provided inside the container.