### PR TITLE
fix: merge .env files with proper precedence and add temporary env var name aliasing

### DIFF
--- a/lib/commands/build/build.ts
+++ b/lib/commands/build/build.ts
@@ -1,11 +1,12 @@
 import { dirname } from 'path';
 import { mkdir, writeFile } from 'fs/promises';
 import { validateConfig, type AzionPrebuildResult, type BuildContext } from 'azion/config';
-import { debug, copyEnvVars, executeCleanup, markForCleanup } from '#utils';
+import { debug, copyEnvVars, executeCleanup, markForCleanup, writePrefixedEnvVars } from '#utils';
 import { BUILD_CONFIG_DEFAULTS, DOCS_MESSAGE } from '#constants';
 import { feedback } from 'azion/utils/node';
 
 import { checkDependencies } from './utils';
+import { resolveApplicationName } from '../../env/alias';
 
 /* Modules */
 import { setupBuildConfig } from './modules/config';
@@ -29,6 +30,7 @@ export const build = async (buildParams: BuildParams): Promise<BuildResult> => {
 
     const resolvedPreset = await resolvePreset(config.build?.preset);
     const buildConfigSetup = await setupBuildConfig(config, resolvedPreset, isProduction);
+    const applicationName = resolveApplicationName(process.cwd());
 
     /* Execute build phases */
     // Phase 1: Prebuild
@@ -41,6 +43,7 @@ export const build = async (buildParams: BuildParams): Promise<BuildResult> => {
         skipFrameworkBuild: Boolean(options.skipFrameworkBuild),
         handler: '', // Placeholder, will be set later
       },
+      applicationName,
     });
 
     feedback.prebuild.info('Pre-build completed successfully');
@@ -97,7 +100,11 @@ export const build = async (buildParams: BuildParams): Promise<BuildResult> => {
       ctx,
     });
 
-    await copyEnvVars();
+    await copyEnvVars(ctx.production);
+    /**
+     * Temporary workaround for Azion's global environment variables
+     */
+    await writePrefixedEnvVars(applicationName, ctx.production);
 
     return {
       config: mergedConfig,

--- a/lib/commands/build/modules/prebuild/prebuild.ts
+++ b/lib/commands/build/modules/prebuild/prebuild.ts
@@ -5,6 +5,7 @@ import { DIRECTORIES, BUNDLER } from '#constants';
 export interface PrebuildParams {
   buildConfig: BuildConfiguration;
   ctx: BuildContext;
+  applicationName?: string;
 }
 
 const DEFAULT_PREBUILD_RESULT: AzionPrebuildResult = {
@@ -23,6 +24,7 @@ const DEFAULT_PREBUILD_RESULT: AzionPrebuildResult = {
 export const executePrebuild = async ({
   buildConfig,
   ctx,
+  applicationName,
 }: PrebuildParams): Promise<AzionPrebuildResult> => {
   const result = (await buildConfig.preset.prebuild?.(buildConfig, ctx)) || DEFAULT_PREBUILD_RESULT;
 
@@ -62,6 +64,16 @@ export const executePrebuild = async ({
 
   const globalThisWithInjections = `${globalThisWithVars}${pathPrefix}\n${memoryFiles}`;
 
+  /**
+   * Temporary workaround for Azion's global environment variables.
+   * Only applies to production builds: in `bundler dev` the local .env already has the plain
+   * (unprefixed) names, so rewriting them would make the app look for a var that only exists
+   * on the platform, breaking local dev.
+   */
+  const envAliasDefineVars = ctx.production
+    ? await utils.buildEnvAliasDefineVars(process.cwd(), applicationName)
+    : {};
+
   return {
     filesToInject: result.filesToInject || [],
     injection: {
@@ -70,7 +82,7 @@ export const executePrebuild = async ({
       banner: globalThisWithInjections,
     },
     bundler: {
-      defineVars: result.bundler?.defineVars || {},
+      defineVars: { ...result.bundler?.defineVars, ...envAliasDefineVars },
       plugins: result.bundler?.plugins || [],
     },
   };

--- a/lib/commands/build/modules/prebuild/utils.ts
+++ b/lib/commands/build/modules/prebuild/utils.ts
@@ -1,5 +1,7 @@
 import fsPromises from 'fs/promises';
 import { join } from 'path';
+import { resolveEnvAliasPrefix } from '../../../../env/alias';
+import { resolveMergedEnvEntries } from '../../../../env/dotenv';
 
 interface WorkerGlobalsConfig {
   namespace: string;
@@ -80,6 +82,41 @@ export const injectWorkerGlobals = ({ namespace, property, vars }: WorkerGlobals
     property ? `globalThis.${namespace}.${property}={};` : `globalThis.${namespace}={};`,
   );
 
+/**
+ * Temporary workaround for Azion's global environment variables (see ENV_ALIAS in constants.ts).
+ * Reads the key names declared in the project's .env file and, if a prefix is available, returns
+ * esbuild `define` entries that rewrite `process.env.${KEY}` to `process.env.${prefix}${KEY}`
+ * directly in the compiled code — a build-time text substitution, not a runtime assignment.
+ *
+ * On Azion's production runtime, `process`/`process.env` are fully read-only (both mutating
+ * individual keys and swapping the whole `env`/`process` reference throw "Cannot set on
+ * process.env"), so there is no way to remap env names from injected runtime code. Rewriting the
+ * property name at build time sidesteps that entirely, since it only changes what the compiled
+ * code reads — it never writes to `process.env`.
+ *
+ * The prefix comes from AZ_BUNDLER_ENV_ALIAS_PREFIX when set (explicit override), otherwise it's
+ * derived from the application name.
+ *
+ * Limitation: esbuild's `define` only rewrites statically-analyzable references
+ * (`process.env.KEY` or `process.env['KEY']` with a literal key). Code that reads env vars via a
+ * computed key (`process.env[someVariable]`), or via a library that captures `process.env` into
+ * an alias/parameter and reads from that, won't be caught by this.
+ */
+export const buildEnvAliasDefineVars = async (
+  cwd: string,
+  applicationName?: string,
+): Promise<Record<string, string>> => {
+  const prefix = resolveEnvAliasPrefix(applicationName);
+  if (!prefix) return {};
+
+  const entries = await resolveMergedEnvEntries(cwd, true);
+  if (entries.length === 0) return {};
+
+  return Object.fromEntries(
+    entries.map(({ key }) => [`process.env.${key}`, `process.env.${prefix}${key}`]),
+  );
+};
+
 export const injectWorkerPathPrefix = async ({
   namespace,
   property,
@@ -98,4 +135,5 @@ export default {
   copyFilesToLocalEdgeStorage,
   injectWorkerGlobals,
   injectWorkerPathPrefix,
+  buildEnvAliasDefineVars,
 };

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -10,6 +10,10 @@ export const DIRECTORIES = {
   OUTPUT_STORAGE_PATH: join('.edge', 'storage'),
   OUTPUT_MANIFEST_PATH: join('.edge', 'manifest.json'),
   OUTPUT_ENV_VARS_PATH: join('.edge', '.env'),
+  /**
+   * Temporary workaround for Azion's global environment variables
+   */
+  OUTPUT_ENV_VARS_LOCAL_PATH: join('.edge', '.env.azion'),
 } as const;
 
 /** Default build configuration values */
@@ -61,6 +65,23 @@ export const BUNDLER = {
   get VERSION() {
     return BUNDLER.PACKAGE_JSON.version;
   },
+} as const;
+
+/**
+ * Temporary workaround for Azion's global (non-project-scoped) environment variables.
+ * Opt-in via `azbundler build --alias-env` (which sets AZ_BUNDLER_ENV_ALIAS_ENABLED). Off by
+ * default so existing deploys built with plain env var names keep working unchanged.
+ *
+ * When enabled, on production builds the bundler reads the keys declared in the project's .env
+ * file and rewrites `process.env.${KEY}` to `process.env.${PREFIX}${KEY}` in the compiled bundle
+ * (via esbuild `define`). This lets a project store its values under a unique global name
+ * (avoiding cross-project name collisions) while libraries keep reading the plain expected name.
+ *
+ * Remove once Azion supports project-scoped environment variables.
+ */
+export const ENV_ALIAS = {
+  ENV_PREFIX_VAR: 'AZ_BUNDLER_ENV_ALIAS_PREFIX',
+  ENABLE_VAR: 'AZ_BUNDLER_ENV_ALIAS_ENABLED',
 } as const;
 
 export const DOCS_MESSAGE = `

--- a/lib/env/alias.ts
+++ b/lib/env/alias.ts
@@ -1,0 +1,59 @@
+/**
+ * Temporary workaround for Azion's global (non-project-scoped) environment variables.
+ * See ENV_ALIAS in constants.ts. Remove once Azion supports project-scoped environment variables.
+ */
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { ENV_ALIAS } from '#constants';
+
+/**
+ * Resolves the project's application name to derive the env alias prefix from. This API version
+ * has no `applications`/`edgeApplications` config, so the name comes from the user's project
+ * instead: `azion/azion.json`'s `name` field when that file exists, otherwise `package.json`'s
+ * `name`. Malformed JSON is ignored (falls through to the next source, or undefined).
+ */
+export const resolveApplicationName = (cwd: string): string | undefined => {
+  const azionJsonPath = join(cwd, 'azion', 'azion.json');
+  if (existsSync(azionJsonPath)) {
+    try {
+      const azionJson = JSON.parse(readFileSync(azionJsonPath, 'utf-8'));
+      if (typeof azionJson?.name === 'string' && azionJson.name) return azionJson.name;
+    } catch {
+      // malformed azion.json, fall through to package.json
+    }
+  }
+
+  const packageJsonPath = join(cwd, 'package.json');
+  if (existsSync(packageJsonPath)) {
+    try {
+      const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
+      if (typeof packageJson?.name === 'string' && packageJson.name) return packageJson.name;
+    } catch {
+      // malformed package.json
+    }
+  }
+
+  return undefined;
+};
+
+/**
+ * Turns an application name into a safe env var prefix, e.g. "My Cool App" -> "MY_COOL_APP_".
+ * Returns '' if the name has no alphanumeric characters to build a prefix from.
+ */
+export const sanitizeEnvPrefix = (name: string): string => {
+  const core = name
+    .toUpperCase()
+    .replace(/[^A-Z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '');
+  return core ? `${core}_` : '';
+};
+
+/**
+ * Resolves the env alias prefix. Opt-in: returns '' unless AZ_BUNDLER_ENV_ALIAS_ENABLED is set
+ * (set by the `--alias-env` build flag). When enabled, the prefix comes from
+ * AZ_BUNDLER_ENV_ALIAS_PREFIX (explicit override), otherwise derived from the application name.
+ */
+export const resolveEnvAliasPrefix = (applicationName?: string): string => {
+  if (process.env[ENV_ALIAS.ENABLE_VAR] !== 'true') return '';
+  return process.env[ENV_ALIAS.ENV_PREFIX_VAR] || sanitizeEnvPrefix(applicationName || '');
+};

--- a/lib/env/dotenv.ts
+++ b/lib/env/dotenv.ts
@@ -1,0 +1,69 @@
+import fs from 'fs';
+import fsPromises from 'fs/promises';
+import { join } from 'path';
+
+export interface EnvFileEntry {
+  key: string;
+  value: string;
+}
+
+/**
+ * Parses KEY=VALUE lines from a .env file's content, skipping comments and blank lines.
+ * Values are returned raw (no quote stripping or expansion) — this keeps generated files
+ * (.edge/.env, .edge/.env.azion) byte-faithful to what the user wrote. Callers that inject a
+ * value into a live JS context should unwrap quotes themselves; see `unwrapEnvValue`.
+ */
+export const parseEnvFileEntries = (content: string): EnvFileEntry[] =>
+  content
+    .split('\n')
+    .map((line) => line.match(/^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)$/))
+    .filter((match): match is RegExpMatchArray => Boolean(match))
+    .map((match) => ({ key: match[1], value: match[2] }));
+
+/**
+ * Strips a single matching pair of surrounding quotes (single or double), like standard .env
+ * parsers do, e.g. `"http://localhost:3333"` -> `http://localhost:3333`. Also trims trailing
+ * `\r` from CRLF line endings. Unquoted values are just trimmed.
+ */
+export const unwrapEnvValue = (rawValue: string): string => {
+  const trimmed = rawValue.trim().replace(/\r$/, '');
+  const isQuoted =
+    trimmed.length >= 2 &&
+    ((trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+      (trimmed.startsWith("'") && trimmed.endsWith("'")));
+  return isQuoted ? trimmed.slice(1, -1) : trimmed;
+};
+
+/**
+ * .env file precedence, highest priority first — same convention as Next.js:
+ * https://nextjs.org/docs/pages/guides/environment-variables#environment-variable-load-order
+ */
+const envFilePrecedence = (production: boolean): string[] =>
+  production
+    ? ['.env.production.local', '.env.local', '.env.production', '.env']
+    : ['.env.development.local', '.env.local', '.env.development', '.env'];
+
+/**
+ * Merges the project's .env* files into a single set of entries, following the precedence order
+ * above. Files earlier in the precedence list win on key conflicts.
+ */
+export async function resolveMergedEnvEntries(
+  cwd: string,
+  production: boolean,
+): Promise<EnvFileEntry[]> {
+  const merged = new Map<string, string>();
+
+  for (const fileName of [...envFilePrecedence(production)].reverse()) {
+    const filePath = join(cwd, fileName);
+    const exists = await fsPromises
+      .access(filePath, fs.constants.F_OK)
+      .then(() => true)
+      .catch(() => false);
+    if (!exists) continue;
+
+    const content = await fsPromises.readFile(filePath, 'utf-8');
+    parseEnvFileEntries(content).forEach(({ key, value }) => merged.set(key, value));
+  }
+
+  return Array.from(merged, ([key, value]) => ({ key, value }));
+}

--- a/lib/env/runtime.ts
+++ b/lib/env/runtime.ts
@@ -17,7 +17,31 @@ import {
   cryptoContext,
   promisesContext,
 } from 'azion/bundler/polyfills';
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
 import { EdgeContext, EdgeVM } from './edge-vm';
+import { DIRECTORIES } from '#constants';
+import { parseEnvFileEntries, unwrapEnvValue } from './dotenv';
+
+/**
+ * Loads the env vars the build already merged into .edge/.env (see copyEnvVars in utils.ts),
+ * so the dev sandbox sees the same values a deployed function would (respecting .env.local,
+ * .env.development, etc. precedence) instead of just the CLI process's own environment.
+ * Falls back to process.env if .edge/.env doesn't exist yet (e.g. no .env files in the project).
+ *
+ * Values are unwrapped from surrounding quotes here (not in the shared parser), since this is
+ * the only place a value becomes a literal string handed to a live JS context — .edge/.env and
+ * .edge/.env.azion stay byte-faithful to what the user wrote.
+ */
+function loadSandboxEnv(): Record<string, string | undefined> {
+  const edgeEnvPath = join(process.cwd(), DIRECTORIES.OUTPUT_ENV_VARS_PATH);
+  if (!existsSync(edgeEnvPath)) return { ...process.env };
+
+  const content = readFileSync(edgeEnvPath, 'utf-8');
+  return Object.fromEntries(
+    parseEnvFileEntries(content).map(({ key, value }) => [key, unwrapEnvValue(value)]),
+  );
+}
 
 /**
  * Executes the specified JavaScript code within a sandbox environment,
@@ -67,7 +91,7 @@ function runtime(code: string, isFirewallEvent = false) {
     // eslint-disable-next-line no-eval
     context.eval = eval;
     /* ==== Cells Runtime/Azion have this interface ==== */
-    context.process = { env: process.env };
+    context.process = { env: loadSandboxEnv() };
 
     /* ==== Cells Runtime/Azion does not have this interface ==== */
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -3,7 +3,7 @@ import { Command } from 'commander';
 import { satisfies } from 'semver';
 import { executeCleanup, debug } from '#utils';
 import { feedback } from 'azion/utils/node';
-import { BUNDLER } from '#constants';
+import { BUNDLER, ENV_ALIAS } from '#constants';
 import { createHash } from 'crypto';
 import { mkdir } from 'fs/promises';
 import type { BundlerGlobals } from '#types';
@@ -129,11 +129,21 @@ function startBundler() {
     .option('-d, --dev', 'Build in development mode', false)
     .option('-x, --experimental [boolean]', 'Enable experimental features', false)
     .option('--skip-framework-build', 'Skip framework build step', false)
+    .option(
+      '--alias-env',
+      'Temporary: rewrite env var names to a per-project prefix to avoid cross-project naming collisions',
+      false,
+    )
     .action(async (options) => {
       const { buildCommand, manifestCommand } = await import('#commands');
-      const { dev, experimental, ...buildOptions } = options;
+      const { dev, experimental, aliasEnv, ...buildOptions } = options;
 
       if (experimental) globalThis.bundler.experimental = true;
+
+      // Handle alias-env flag (temporary env var name aliasing, see ENV_ALIAS in constants.ts)
+      if (aliasEnv) {
+        process.env[ENV_ALIAS.ENABLE_VAR] = 'true';
+      }
 
       const { config } = await buildCommand({
         ...buildOptions,

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,9 +1,9 @@
 import { unlinkSync } from 'fs';
-import { join } from 'path';
-import { readFile, writeFile, access } from 'fs/promises';
-import { constants } from 'fs';
+import { writeFile } from 'fs/promises';
 import { DIRECTORIES } from '#constants';
 import { readStore, writeStore } from '#env';
+import { resolveEnvAliasPrefix } from './env/alias';
+import { resolveMergedEnvEntries } from './env/dotenv';
 
 /**
  * @function markForCleanup
@@ -156,32 +156,63 @@ Object.keys(console).forEach((method: string) => {
 
 /**
  * @function
- * @description Copies the .env file from the project root to the .edge directory.
- * Following Node.js native .env support pattern.
+ * @description Copies the project's .env* files to the .edge directory as a single merged file.
+ * Follows the same .env precedence order as Next.js (see env/dotenv.ts): `.env.<mode>.local`,
+ * `.env.local`, `.env.<mode>`, `.env`, where files earlier in that list win on key conflicts.
  * @example
  *
  * // Example usage:
- * await copyEnvToEdge();
- * // Copies .env to .edge/.env if it exists
+ * await copyEnvVars(true);
+ * // Merges .env, .env.production, .env.local, .env.production.local into .edge/.env
  */
-async function copyEnvVars(): Promise<void> {
+async function copyEnvVars(production = true): Promise<void> {
   const cwd = process.cwd();
-  const envPath = join(cwd, '.env');
   const edgeEnvPath = DIRECTORIES.OUTPUT_ENV_VARS_PATH;
 
   try {
-    const exists = await access(envPath, constants.F_OK)
-      .then(() => true)
-      .catch(() => false);
+    const entries = await resolveMergedEnvEntries(cwd, production);
+    if (entries.length === 0) return;
 
-    if (exists) {
-      const envContent = await readFile(envPath, 'utf-8');
-      await writeFile(edgeEnvPath, envContent, 'utf-8');
-      debug.info(`Environment file copied to ${edgeEnvPath}`);
-    }
+    const envContent = entries.map(({ key, value }) => `${key}=${value}`).join('\n');
+    await writeFile(edgeEnvPath, `${envContent}\n`, 'utf-8');
+    debug.info(`Environment file copied to ${edgeEnvPath}`);
   } catch (error) {
     debug.warn('No .env file found or error copying environment file');
   }
 }
 
-export { executeCleanup, generateTimestamp, debug, copyEnvVars, markForCleanup };
+/**
+ * @function
+ * @description Temporary workaround for Azion's global environment variables (see ENV_ALIAS in
+ * constants.ts). Writes the project's merged .env* entries to .edge/.env.azion under a prefixed
+ * name (AZ_BUNDLER_ENV_ALIAS_PREFIX, or derived from the application name), so the CLI can
+ * create/sync those as uniquely-named global env vars instead of the plain, collision-prone names.
+ * Remove once Azion supports project-scoped environment variables.
+ */
+async function writePrefixedEnvVars(applicationName?: string, production = true): Promise<void> {
+  const prefix = resolveEnvAliasPrefix(applicationName);
+  if (!prefix) return;
+
+  const cwd = process.cwd();
+  const prefixedEnvPath = DIRECTORIES.OUTPUT_ENV_VARS_LOCAL_PATH;
+
+  try {
+    const entries = await resolveMergedEnvEntries(cwd, production);
+    if (entries.length === 0) return;
+
+    const prefixedContent = entries.map(({ key, value }) => `${prefix}${key}=${value}`).join('\n');
+    await writeFile(prefixedEnvPath, `${prefixedContent}\n`, 'utf-8');
+    debug.info(`Prefixed environment file written to ${prefixedEnvPath}`);
+  } catch (error) {
+    debug.warn('No .env file found or error writing prefixed environment file');
+  }
+}
+
+export {
+  executeCleanup,
+  generateTimestamp,
+  debug,
+  copyEnvVars,
+  writePrefixedEnvVars,
+  markForCleanup,
+};


### PR DESCRIPTION
## Summary

- Merge `.env`, `.env.local`, `.env.<mode>`, and `.env.<mode>.local` following Next.js's precedence order wherever env vars are read for the build (`copyEnvVars`, prefixed env generation).
- The local dev sandbox now reads the merged `.edge/.env` instead of the CLI process's own environment, and unwraps quoted values there — fixes a quoted URL being seen as a literal string with embedded quotes.
- Add opt-in support (`--alias-env` build flag, **off by default**) for rewriting env var names to a per-project prefix, to avoid cross-project naming collisions on Azion's global environment variables. The rewrite happens at build time via esbuild `define`, since `process`/`process.env` are read-only on Azion's production runtime.

## Test plan

- [ ] Build a project without `--alias-env` and confirm behavior is unchanged
- [ ] Build a project with multiple `.env*` files (`.env`, `.env.local`, `.env.production`) and confirm the merged `.edge/.env` respects the expected precedence
- [ ] Build with `--alias-env` and confirm `.edge/.env.azion` is generated with the prefixed names
- [ ] Run `azbundler dev` with a quoted value in `.env` (e.g. `NEXTAUTH_URL="http://localhost:3333"`) and confirm it resolves without duplicated quotes
